### PR TITLE
Pagination and Updated DynamoDB structure

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -95,11 +95,22 @@ Resources:
           AttributeType: S
         - AttributeName: recordingId
           AttributeType: S
+        - AttributeName: createdAt
+          AttributeType: S
       KeySchema:
         - AttributeName: userId
           KeyType: HASH
         - AttributeName: recordingId
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: UserCreatedAtIndex
+          KeySchema:
+            - AttributeName: userId
+              KeyType: HASH
+            - AttributeName: createdAt
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
 
   WorkoutsTable:
     Type: AWS::DynamoDB::Table
@@ -111,11 +122,22 @@ Resources:
           AttributeType: S
         - AttributeName: workoutId
           AttributeType: S
+        - AttributeName: completedAt
+          AttributeType: S
       KeySchema:
         - AttributeName: userId
           KeyType: HASH
         - AttributeName: workoutId
           KeyType: RANGE
+      GlobalSecondaryIndexes:
+        - IndexName: UserCompletedAtIndex
+          KeySchema:
+            - AttributeName: userId
+              KeyType: HASH
+            - AttributeName: completedAt
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
 
   UploadBucket:
     Type: AWS::S3::Bucket
@@ -209,7 +231,13 @@ Resources:
           ROWLYTICS_TEAM_MEMBERS_USER_INDEX: UserIdIndex
           ROWLYTICS_TEAMS_NAME_INDEX: TeamNameIndex
           ROWLYTICS_RECORDINGS_TABLE: !Ref RecordingsTable
+          ROWLYTICS_RECORDINGS_CREATED_AT_INDEX: UserCreatedAtIndex
           ROWLYTICS_WORKOUTS_TABLE: !Ref WorkoutsTable
+          ROWLYTICS_WORKOUTS_COMPLETED_AT_INDEX: UserCompletedAtIndex
+          ROWLYTICS_MAX_PAGE_SIZE: "50"
+          ROWLYTICS_TEAM_MEMBERS_PAGE_SIZE: "20"
+          ROWLYTICS_RECORDINGS_PAGE_SIZE: "8"
+          ROWLYTICS_WORKOUTS_PAGE_SIZE: "8"
           ROWLYTICS_UPLOAD_BUCKET: !Ref UploadBucket
           ROWLYTICS_COGNITO_DOMAIN: !Sub "${CognitoDomainPrefix}.auth.${AWS::Region}.amazoncognito.com"
           ROWLYTICS_COGNITO_CLIENT_ID: !Ref UserPoolClient

--- a/rowlytics_app/services/dynamodb.py
+++ b/rowlytics_app/services/dynamodb.py
@@ -25,6 +25,14 @@ TEAM_MEMBERS_USER_INDEX = os.getenv("ROWLYTICS_TEAM_MEMBERS_USER_INDEX", "UserId
 TEAM_NAME_INDEX = os.getenv("ROWLYTICS_TEAMS_NAME_INDEX", "TeamNameIndex")
 RECORDINGS_TABLE_NAME = os.getenv("ROWLYTICS_RECORDINGS_TABLE", "RowlyticsRecordings")
 WORKOUTS_TABLE_NAME = os.getenv("ROWLYTICS_WORKOUTS_TABLE", "RowlyticsWorkouts")
+RECORDINGS_CREATED_AT_INDEX = os.getenv(
+    "ROWLYTICS_RECORDINGS_CREATED_AT_INDEX",
+    "UserCreatedAtIndex",
+)
+WORKOUTS_COMPLETED_AT_INDEX = os.getenv(
+    "ROWLYTICS_WORKOUTS_COMPLETED_AT_INDEX",
+    "UserCompletedAtIndex",
+)
 
 
 def now_iso() -> str:
@@ -266,6 +274,15 @@ def query_all(table, **kwargs):
     return items
 
 
+def query_page(table, *, limit: int, exclusive_start_key=None, **kwargs):
+    query_kwargs = dict(kwargs)
+    query_kwargs["Limit"] = limit
+    if exclusive_start_key:
+        query_kwargs["ExclusiveStartKey"] = exclusive_start_key
+    response = table.query(**query_kwargs)
+    return response.get("Items", []), response.get("LastEvaluatedKey")
+
+
 def scan_all(table, **kwargs):
     items = []
     last_key = None
@@ -335,17 +352,118 @@ def list_owned_teams(teams_table, user_id: str):
 
 
 def list_recordings(recordings_table, user_id: str):
-    return query_all(
+    try:
+        return query_all(
+            recordings_table,
+            IndexName=RECORDINGS_CREATED_AT_INDEX,
+            KeyConditionExpression=Key("userId").eq(user_id),
+            ScanIndexForward=False,
+        )
+    except Exception as err:
+        logger.warning("list_recordings: index query failed, using fallback query: %s", err)
+        if ClientError and isinstance(err, ClientError):
+            error_code = err.response.get("Error", {}).get("Code")
+            if error_code not in {"ValidationException", "ResourceNotFoundException"}:
+                raise
+        else:
+            raise
+
+        items = query_all(
+            recordings_table,
+            KeyConditionExpression=Key("userId").eq(user_id),
+        )
+        return sorted(items, key=lambda item: item.get("createdAt") or "", reverse=True)
+
+
+def list_recordings_page(recordings_table, user_id: str, limit: int, exclusive_start_key=None):
+    return query_page(
         recordings_table,
+        IndexName=RECORDINGS_CREATED_AT_INDEX,
         KeyConditionExpression=Key("userId").eq(user_id),
+        ScanIndexForward=False,
+        limit=limit,
+        exclusive_start_key=exclusive_start_key,
     )
 
 
 def list_workouts(workouts_table, user_id: str):
-    return query_all(
+    try:
+        return query_all(
+            workouts_table,
+            IndexName=WORKOUTS_COMPLETED_AT_INDEX,
+            KeyConditionExpression=Key("userId").eq(user_id),
+            ScanIndexForward=False,
+        )
+    except Exception as err:
+        logger.warning("list_workouts: index query failed, using fallback query: %s", err)
+        if ClientError and isinstance(err, ClientError):
+            error_code = err.response.get("Error", {}).get("Code")
+            if error_code not in {"ValidationException", "ResourceNotFoundException"}:
+                raise
+        else:
+            raise
+
+        items = query_all(
+            workouts_table,
+            KeyConditionExpression=Key("userId").eq(user_id),
+        )
+        return sorted(
+            items,
+            key=lambda item: item.get("completedAt") or item.get("createdAt") or "",
+            reverse=True,
+        )
+
+
+def list_workouts_page(workouts_table, user_id: str, limit: int, exclusive_start_key=None):
+    return query_page(
         workouts_table,
+        IndexName=WORKOUTS_COMPLETED_AT_INDEX,
         KeyConditionExpression=Key("userId").eq(user_id),
+        ScanIndexForward=False,
+        limit=limit,
+        exclusive_start_key=exclusive_start_key,
     )
+
+
+def fetch_team_members_page(
+    users_table,
+    team_members_table,
+    team_id: str,
+    allowed_roles: set[str],
+    limit: int,
+    exclusive_start_key=None,
+):
+    query_kwargs = {
+        "KeyConditionExpression": Key("teamId").eq(team_id),
+        "Limit": limit,
+    }
+    if exclusive_start_key:
+        query_kwargs["ExclusiveStartKey"] = exclusive_start_key
+
+    response = team_members_table.query(
+        **query_kwargs,
+    )
+    items = response.get("Items", [])
+    user_ids = [item.get("userId") for item in items if item.get("userId")]
+    users_by_id = batch_get_users(users_table, user_ids)
+
+    members = []
+    for item in items:
+        user_id = item.get("userId")
+        user = users_by_id.get(user_id, {})
+        raw_role = item.get("memberRole")
+        role = raw_role.lower() if isinstance(raw_role, str) else "rower"
+        if role not in allowed_roles:
+            role = "coach" if "coach" in role else "rower"
+
+        members.append({
+            "userId": user_id,
+            "memberRole": role,
+            "joinedAt": item.get("joinedAt"),
+            "name": user.get("name"),
+            "email": user.get("email"),
+        })
+    return members, response.get("LastEvaluatedKey")
 
 
 def team_name_exists(teams_table, team_name: str) -> bool:

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -731,6 +731,14 @@ body {
   font-size: 0.85rem;
 }
 
+.team-load-more {
+  justify-self: center;
+}
+
+.team-load-more--hidden {
+  display: none;
+}
+
 .team-message {
   min-height: 1.2rem;
   font-size: 0.9rem;
@@ -889,6 +897,14 @@ body {
 .recordings-empty {
   color: var(--color-muted-dark);
   font-size: 0.9rem;
+}
+
+.recordings-load-more {
+  justify-self: center;
+}
+
+.recordings-load-more--hidden {
+  display: none;
 }
 
 /* Auth */

--- a/rowlytics_app/templates/snapshot_library.html
+++ b/rowlytics_app/templates/snapshot_library.html
@@ -27,6 +27,13 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
         <p>Auto-captured clips appear here after uploads finish.</p>
       </div>
       <div id="recordingsGrid" class="recordings-grid"></div>
+      <button
+        id="recordingsLoadMore"
+        class="btn btn--subtle recordings-load-more recordings-load-more--hidden"
+        type="button"
+      >
+        Load more clips
+      </button>
       <p id="recordingsMessage" class="recordings-message" aria-live="polite"></p>
     </section>
   </div>

--- a/rowlytics_app/templates/team_view.html
+++ b/rowlytics_app/templates/team_view.html
@@ -61,6 +61,13 @@
 
           <h3>Members</h3>
           <ul id="teamMembersList" class="team-members"></ul>
+          <button
+            id="teamMembersLoadMore"
+            class="btn btn--subtle team-load-more team-load-more--hidden"
+            type="button"
+          >
+            Load more members
+          </button>
 
           <h3>Add Member</h3>
           <form id="teamAddForm" class="team-form">

--- a/rowlytics_app/templates/workout_summaries.html
+++ b/rowlytics_app/templates/workout_summaries.html
@@ -28,6 +28,13 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
         <p>Each entry includes duration, timestamp, summary, and score when available.</p>
       </div>
       <div id="workoutsGrid" class="recordings-grid"></div>
+      <button
+        id="workoutsLoadMore"
+        class="btn btn--subtle recordings-load-more recordings-load-more--hidden"
+        type="button"
+      >
+        Load more summaries
+      </button>
       <p id="workoutsMessage" class="recordings-message" aria-live="polite"></p>
     </section>
   </div>


### PR DESCRIPTION
Apologies for the monster PR. I know I said I would stop doing this, but at this point it will be pretty tough to split this into multiple PRs. In the future I will try to make a PR no matter what if I get past like 100 or so lines even if there is more stuff I want to add.

This PR addresses the comments left on the PR #76. At a very high level, this PR overhauls how we store stuff in DynamoDB so we can display it better and adds pagination to all pages that load in items.

Here's everything I added/changed with this PR:
- Added "createdAt" to workouts so workout records are consistent and easier to sort/index (as suggested by Kassie)
- Improved DynamoDB schema for scale using shared tables + GSIs (instead of per-user tables). RowlyticsRecordings now has UserCreatedAtIndex / RowlyticsWorkouts now has UserCompletedAtIndex (see template.yaml).
- Updated data access layer to query newest-first directly from GSIs and added paginated page-query helpers with fallback behavior in dynamodb.py.
- Added cursor-based pagination API support (limit, cursor, nextCursor) for team members, recordings, and workouts in api_routes.py with defaults of 20/8/8 and validation/clamping
- Updated frontend to use the pagination and append results with “Load more” controls
- Added team membership safety guard so users cannot be added to a new team if they already belong to another team (this was a bug I found when doing manual testing)
- Added new DynamoDB env/index config wiring in sam so that we can change things like when pagination cuts off without having to write/push code (you can just change the values in the AWS console)

This PR resolves issue #75
This PR at least partially resolves issue #77
