### PR TITLE
adding stack metadata to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
             --stack-name "${{ env.stack_name }}" \
             --region "${{ env.aws_region }}" \
             --capabilities CAPABILITY_NAMED_IAM \
-            --resolve-s3
+            --resolve-s3 \
             --no-fail-on-empty-changeset
 
 


### PR DESCRIPTION
This CI Pipeline updates records the stack name and deploy date in last-deployed-stack. It runs with the dev stack for pull requests because you can't run manual jobs if it's not on the main branch but I think that should be easy to fix if you really wanted to.