### PR TITLE
Fixing sam deployment in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
             --region "${{ env.aws_region }}" \
             --capabilities CAPABILITY_NAMED_IAM \
             --resolve-s3 \
+            --no-confirm-changeset \
             --no-fail-on-empty-changeset
 
 


### PR DESCRIPTION
This PR makes it so when the CI deployment runs, it uses your samconfig file instead of defaults (which might cause issues)