### PR TITLE
Adds a time limit for workout capture

### DIFF
--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -114,6 +114,7 @@ ANGLE_MIN_STROKE_AMPLITUDE = 0.006
 ANGLE_STROKE_AMPLITUDE_SCALE = 0.11
 MOTION_SPIKE_MAX_DELTA_PER_SEC = 1.2
 MOTION_SPIKE_BASE_DELTA = 0.075
+MAX_WORKOUT_DURATION_SEC = 60 * 60
 
 
 class MovementGateError(ValueError):
@@ -1355,6 +1356,10 @@ def save_workout():
 
     if duration_value is None or duration_value <= 0:
         return jsonify({"error": "durationSec must be a positive number"}), 400
+    if duration_value > MAX_WORKOUT_DURATION_SEC:
+        return jsonify({
+            "error": f"durationSec must be less than or equal to {MAX_WORKOUT_DURATION_SEC}",
+        }), 400
 
     duration_value = int(round(duration_value))
 

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -645,6 +645,13 @@ body {
   box-shadow: none;
 }
 
+.capture__note {
+  margin: 0;
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
 .capture__analysis {
   margin-top: 0.5rem;
   border: var(--border-light-soft);

--- a/rowlytics_app/static/js/capture_workout.js
+++ b/rowlytics_app/static/js/capture_workout.js
@@ -11,6 +11,7 @@ const overlay = document.getElementById("poseOverlay");
 const overlayCtx = overlay ? overlay.getContext("2d") : null;
 const viewport = document.querySelector(".capture__viewport");
 const placeholder = document.getElementById("capturePlaceholder");
+const captureSessionNotice = document.getElementById("captureSessionNotice");
 const apiBase = (document.body?.dataset?.apiBase || "").replace(/\/+$/, "");
 const urlParams = (() => {
   try {
@@ -45,12 +46,16 @@ const defaultStatusText = "Side profile not in frame";
 const readyStatusText = "Side profile in frame";
 const userId = document.body?.dataset?.userId || "demo-user";
 const recordingDurationMs = 5000;
+const maxWorkoutDurationMs = 60 * 60 * 1000;
+const maxWorkoutDurationSec = maxWorkoutDurationMs / 1000;
 const inFrameThresholdMs = 5000;
 const recordingCooldownMs = 3000;
 const inFrameDropoutGraceMs = 600;
 const movementGateRetryMs = 1200;
 const movementDebugLogIntervalMs = 500;
 const workoutSummaryText = "Workout session";
+const workoutDurationLimitText = "Workouts automatically stop after 1 hour.";
+const workoutDurationLimitReachedText = "Workout reached the 1-hour limit and stopped automatically.";
 const mobileUserAgentRegex = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i;
 
 let stream = null;
@@ -77,6 +82,8 @@ let overlayWidth = 0;
 let overlayHeight = 0;
 let overlayDpr = 1;
 let workoutStartAt = null;
+let workoutStopDeadlineMs = null;
+let workoutStopTimeout = null;
 let workoutMovementFrames = [];
 let workoutMovementFrameTimesMs = [];
 let movementWindowClipCount = 0;
@@ -120,6 +127,11 @@ const captureDebugEnabled = (() => {
 function debugCapture(event, details = {}) {
   if (!captureDebugEnabled) return;
   console.log(`[capture-workout] ${event}`, details);
+}
+
+function updateCaptureSessionNotice(message = workoutDurationLimitText) {
+  if (!captureSessionNotice) return;
+  captureSessionNotice.textContent = message;
 }
 
 function isLikelyMobileDevice() {
@@ -863,6 +875,49 @@ function resetRecordingTimers() {
   waitingForStrokeGate = false;
 }
 
+function clearWorkoutStopTimeout() {
+  if (workoutStopTimeout) {
+    clearTimeout(workoutStopTimeout);
+    workoutStopTimeout = null;
+  }
+}
+
+function stopWorkoutForDurationLimit() {
+  if (!stream) return;
+  const completedAt = workoutStopDeadlineMs
+    ? new Date(workoutStopDeadlineMs).toISOString()
+    : new Date().toISOString();
+  debugCapture("workout_duration_limit_reached", {
+    completedAt,
+    maxWorkoutDurationSec
+  });
+  updateCaptureSessionNotice(workoutDurationLimitReachedText);
+  stopCamera({
+    stopReason: "time-limit",
+    completedAtOverride: completedAt
+  });
+}
+
+function scheduleWorkoutStopTimeout() {
+  clearWorkoutStopTimeout();
+  if (!workoutStartAt) {
+    workoutStopDeadlineMs = null;
+    return;
+  }
+
+  const workoutStartMs = Date.parse(workoutStartAt);
+  if (!Number.isFinite(workoutStartMs)) {
+    workoutStopDeadlineMs = null;
+    return;
+  }
+
+  workoutStopDeadlineMs = workoutStartMs + maxWorkoutDurationMs;
+  const remainingMs = Math.max(0, workoutStopDeadlineMs - Date.now());
+  workoutStopTimeout = setTimeout(() => {
+    stopWorkoutForDurationLimit();
+  }, remainingMs);
+}
+
 function cancelActiveRecording() {
   recordingCancelled = true;
   if (recorderStopTimeout) {
@@ -1150,6 +1205,7 @@ async function startCamera() {
   lastVideoTime = -1;
   resetRecordingTimers();
   workoutStartAt = new Date().toISOString();
+  scheduleWorkoutStopTimeout();
   workoutMovementFrames = [];
   workoutMovementFrameTimesMs = [];
   movementWindowClipCount = 0;
@@ -1157,6 +1213,7 @@ async function startCamera() {
   latestWorkoutAnalysis = null;
   latestWorkoutAnalysisText = "";
   latestWorkoutScore = null;
+  updateCaptureSessionNotice();
   debugCapture("camera_started", {
     facingMode: preferredFacingMode
   });
@@ -1166,9 +1223,19 @@ async function startCamera() {
   }
 }
 
-function stopCamera() {
+function stopCamera({ stopReason = "manual", completedAtOverride = null } = {}) {
   running = false;
   cancelActiveRecording();
+  clearWorkoutStopTimeout();
+  const deadlineCompletedAt = workoutStopDeadlineMs
+    ? new Date(workoutStopDeadlineMs).toISOString()
+    : null;
+  const completedAt = completedAtOverride || (
+    stopReason === "time-limit" && deadlineCompletedAt
+      ? deadlineCompletedAt
+      : new Date().toISOString()
+  );
+  workoutStopDeadlineMs = null;
   if (stream) {
     stream.getTracks().forEach((t) => t.stop());
     stream = null;
@@ -1194,15 +1261,20 @@ function stopCamera() {
   }
 
   if (workoutStartAt) {
-    const completedAt = new Date().toISOString();
     const durationMs = Date.parse(completedAt) - Date.parse(workoutStartAt);
-    const durationSec = Math.max(1, Math.round(durationMs / 1000));
+    const durationSec = Math.min(
+      maxWorkoutDurationSec,
+      Math.max(1, Math.round(durationMs / 1000))
+    );
     saveWorkoutEntry(durationSec, workoutStartAt, completedAt);
   }
   workoutStartAt = null;
   latestWorkoutAnalysis = null;
   latestWorkoutAnalysisText = "";
   latestWorkoutScore = null;
+  if (stopReason !== "time-limit") {
+    updateCaptureSessionNotice();
+  }
 
   toggleBtn.textContent = "Start";
   toggleBtn.classList.remove("btn--danger");
@@ -1247,6 +1319,10 @@ async function switchCamera() {
 
 function loop() {
   if (!running) return;
+  if (workoutStopDeadlineMs && Date.now() >= workoutStopDeadlineMs) {
+    stopWorkoutForDurationLimit();
+    return;
+  }
   if (!poseLandmarker) {
     requestAnimationFrame(loop);
     return;
@@ -1405,6 +1481,7 @@ window.__rowlyticsCaptureState = () => ({
   lastInFrame,
   lastRawInFrameAtMs,
   waitingForStrokeGate,
+  workoutStopDeadlineMs,
   requestedPoseModel,
   modelCandidates: MP_MODEL_CANDIDATE_PATHS.map((item) => item.key),
   latestWorkoutAnalysis,

--- a/rowlytics_app/templates/capture_workout.html
+++ b/rowlytics_app/templates/capture_workout.html
@@ -50,6 +50,9 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
         Use Rear Camera
       </button>
     </div>
+    <p id="captureSessionNotice" class="capture__note" aria-live="polite">
+      Workouts automatically stop after 1 hour.
+    </p>
   </div>
 </main>
 {% endblock %}

--- a/tests/test_workout_api.py
+++ b/tests/test_workout_api.py
@@ -1,0 +1,62 @@
+"""Tests for workout API validation."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from rowlytics_app import create_app
+
+
+@pytest.fixture()
+def app() -> Flask:
+    flask_app = create_app()
+    flask_app.config.update(TESTING=True, AUTH_REQUIRED=False)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()
+
+
+def test_save_workout_rejects_duration_over_one_hour(
+    client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_workouts_table = MagicMock()
+    monkeypatch.setattr("rowlytics_app.api_routes.get_workouts_table", get_workouts_table)
+
+    with client.session_transaction() as session:
+        session["user_id"] = "user-123"
+
+    response = client.post("/api/workouts", json={"durationSec": 3601})
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "durationSec must be less than or equal to 3600",
+    }
+    get_workouts_table.assert_not_called()
+
+
+def test_save_workout_accepts_one_hour_duration(
+    client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workouts_table = MagicMock()
+    monkeypatch.setattr("rowlytics_app.api_routes.get_workouts_table", lambda: workouts_table)
+
+    with client.session_transaction() as session:
+        session["user_id"] = "user-123"
+
+    response = client.post("/api/workouts", json={"durationSec": 3600})
+
+    assert response.status_code == 201
+    payload = response.get_json()
+    assert payload["status"] == "ok"
+    workouts_table.put_item.assert_called_once()
+    item = workouts_table.put_item.call_args.kwargs["Item"]
+    assert item["userId"] == "user-123"
+    assert item["durationSec"] == 3600


### PR DESCRIPTION
This PR adds a one-hour time limit to workout capture sessions so a forgotten recording cannot create an overly long workout entry.

- Adds a visible note on the capture workout page letting users know workouts automatically stop after 1 hour.
- Starts a one-hour session timer when workout capture begins.
- Automatically stops the workout when the one-hour limit is reached.
- Shows a specific message when the workout is auto-stopped due to the time limit being reached.
- Preserves normal manual stop behavior and resets the notice text for the next session.
- Uses the one-hour deadline timestamp when auto-stopping so the saved workout reflects the capped session end time.
- Clamps the client-side saved workout duration to a maximum of 3600 seconds.
- Adds backend validation on POST /api/workouts so any request with durationSec > 3600 is rejected with a 400.
- Adds API tests covering both
      - rejecting workouts over one hour
      - accepting workouts exactly one hour long