### PR TITLE
fixed display name issue, fixed some mobile UI bugs, and tweaked sign in flow

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -324,16 +324,86 @@ Resources:
           SES_TEST_TO: !Ref SesTestTo
       Policies:
         - AWSLambdaBasicExecutionRole
-        - DynamoDBCrudPolicy:
-            TableName: !Ref UsersTableName
-        - DynamoDBCrudPolicy:
-            TableName: !Ref TeamsTableName
-        - DynamoDBCrudPolicy:
-            TableName: !Ref TeamMembersTableName
-        - DynamoDBCrudPolicy:
-            TableName: !Ref RecordingsTableName
-        - DynamoDBCrudPolicy:
-            TableName: !Ref WorkoutsTableName
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:DeleteItem
+                - dynamodb:PutItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:BatchGetItem
+                - dynamodb:DescribeTable
+                - dynamodb:ConditionCheckItem
+              Resource:
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${UsersTableName}"
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${UsersTableName}/index/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:DeleteItem
+                - dynamodb:PutItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:BatchGetItem
+                - dynamodb:DescribeTable
+                - dynamodb:ConditionCheckItem
+              Resource:
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TeamsTableName}"
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TeamsTableName}/index/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:DeleteItem
+                - dynamodb:PutItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:BatchGetItem
+                - dynamodb:DescribeTable
+                - dynamodb:ConditionCheckItem
+              Resource:
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TeamMembersTableName}"
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${TeamMembersTableName}/index/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:DeleteItem
+                - dynamodb:PutItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:BatchGetItem
+                - dynamodb:DescribeTable
+                - dynamodb:ConditionCheckItem
+              Resource:
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RecordingsTableName}"
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${RecordingsTableName}/index/*"
+        - Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:DeleteItem
+                - dynamodb:PutItem
+                - dynamodb:Scan
+                - dynamodb:Query
+                - dynamodb:UpdateItem
+                - dynamodb:BatchWriteItem
+                - dynamodb:BatchGetItem
+                - dynamodb:DescribeTable
+                - dynamodb:ConditionCheckItem
+              Resource:
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${WorkoutsTableName}"
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${WorkoutsTableName}/index/*"
         - S3CrudPolicy:
             BucketName: !Ref UploadBucketName
         - Statement:

--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -21,6 +21,7 @@ from rowlytics_app.cv.feature_extraction.angles import normalized_joint_angle
 from rowlytics_app.services.dynamodb import (
     fetch_team_members,
     fetch_team_members_page,
+    fetch_user_profile,
     get_ddb_tables,
     get_recordings_table,
     get_team,
@@ -1120,6 +1121,32 @@ def update_account_name():
 
     session["user_name"] = name
     return jsonify({"status": "ok", "name": name})
+
+
+@api_bp.route("/account/profile", methods=["GET"])
+def get_account_profile():
+    user_id = session.get("user_id")
+    if not user_id:
+        return jsonify({"error": "authentication required"}), 401
+
+    try:
+        profile = fetch_user_profile(user_id)
+    except Exception as err:
+        return jsonify({"error": "Unable to load account profile", "detail": str(err)}), 500
+
+    current_name = profile.get("name") or session.get("user_name")
+    current_email = profile.get("email") or session.get("user_email")
+
+    if current_name:
+        session["user_name"] = current_name
+    if current_email:
+        session["user_email"] = current_email
+
+    return jsonify({
+        "userId": user_id,
+        "name": current_name,
+        "email": current_email,
+    })
 
 
 @api_bp.route("/account/delete", methods=["POST"])

--- a/rowlytics_app/auth/cognito.py
+++ b/rowlytics_app/auth/cognito.py
@@ -29,19 +29,38 @@ def decode_token_payload(token: str) -> dict:
         return {}
 
 
-def build_cognito_login_url() -> str | None:
+def _build_cognito_ui_url(
+    path: str,
+    *,
+    screen_hint: str | None = None,
+    login_hint: str | None = None,
+) -> str | None:
     domain = current_app.config.get("COGNITO_DOMAIN")
     client_id = current_app.config.get("COGNITO_CLIENT_ID")
     redirect_uri = current_app.config.get("COGNITO_REDIRECT_URI")
     if not domain or not client_id or not redirect_uri:
         return None
-    query = parse.urlencode({
+    params = {
         "client_id": client_id,
         "response_type": "code",
         "scope": "openid email profile aws.cognito.signin.user.admin",
         "redirect_uri": redirect_uri,
-    })
-    return f"https://{domain}/oauth2/authorize?{query}"
+    }
+    if screen_hint:
+        params["screen_hint"] = screen_hint
+    if login_hint:
+        params["login_hint"] = login_hint
+
+    query = parse.urlencode(params)
+    return f"https://{domain}{path}?{query}"
+
+
+def build_cognito_login_url() -> str | None:
+    return _build_cognito_ui_url("/oauth2/authorize")
+
+
+def build_cognito_signup_url() -> str | None:
+    return _build_cognito_ui_url("/signup")
 
 
 def exchange_code_for_tokens(code: str) -> dict:

--- a/rowlytics_app/routes.py
+++ b/rowlytics_app/routes.py
@@ -6,6 +6,7 @@ import time
 from dataclasses import dataclass
 from typing import Iterable
 from urllib import parse
+from uuid import UUID
 
 from flask import (
     Blueprint,
@@ -20,11 +21,12 @@ from flask import (
 
 from rowlytics_app.auth.cognito import (
     build_cognito_login_url,
+    build_cognito_signup_url,
     decode_token_payload,
     exchange_code_for_tokens,
 )
 from rowlytics_app.auth.sessions import user_context
-from rowlytics_app.services.dynamodb import sync_user_profile
+from rowlytics_app.services.dynamodb import fetch_user_profile, sync_user_profile
 from rowlytics_app.services.metrics import publish_login_latency
 from rowlytics_app.services.mock_email import send_mock_auto_email
 
@@ -113,6 +115,35 @@ def _get_card(slug: str) -> TemplateCard | None:
     return next((card for card in TEMPLATE_CARDS if card.slug == slug), None)
 
 
+def _looks_generated_display_name(
+    name: str | None,
+    *,
+    user_id: str | None = None,
+    username: str | None = None,
+) -> bool:
+    if not name:
+        return True
+
+    candidate = name.strip()
+    if not candidate:
+        return True
+
+    if candidate == "New Rower":
+        return True
+
+    if user_id and candidate == user_id:
+        return True
+
+    if username and candidate == username:
+        return True
+
+    try:
+        UUID(candidate)
+        return True
+    except ValueError:
+        return False
+
+
 @public_bp.route("/")
 def landing_page() -> str:
     return render_template("index.html", cards=TEMPLATE_CARDS, **user_context())
@@ -133,7 +164,11 @@ def profile() -> str:
 
 @public_bp.route("/settings")
 def settings() -> str:
-    return render_template("settings.html", **user_context())
+    return render_template(
+        "settings.html",
+        display_name_required=request.args.get("require_display_name") == "1",
+        **user_context(),
+    )
 
 
 @public_bp.route("/signin")
@@ -141,7 +176,8 @@ def signin() -> str:
     if session.get("user_id"):
         return redirect(url_for("public.landing_page"))
     login_url = build_cognito_login_url()
-    return render_template("sign_in.html", login_url=login_url)
+    signup_url = build_cognito_signup_url()
+    return render_template("sign_in.html", login_url=login_url, signup_url=signup_url)
 
 
 @public_bp.route("/auth/callback")
@@ -151,6 +187,7 @@ def auth_callback() -> str:
     if not code:
         return render_template("sign_in.html",
                                login_url=build_cognito_login_url(),
+                               signup_url=build_cognito_signup_url(),
                                error="Missing auth code."), 400
     try:
         tokens = exchange_code_for_tokens(code)
@@ -158,6 +195,7 @@ def auth_callback() -> str:
         return render_template(
             "sign_in.html",
             login_url=build_cognito_login_url(),
+            signup_url=build_cognito_signup_url(),
             error=f"Auth failed: {err}",
         ), 400
 
@@ -166,15 +204,22 @@ def auth_callback() -> str:
         return render_template(
             "sign_in.html",
             login_url=build_cognito_login_url(),
+            signup_url=build_cognito_signup_url(),
             error="Missing ID token from Cognito.",
         ), 400
 
     payload = decode_token_payload(id_token)
+    raw_name = (payload.get("name") or "").strip() or None
+    raw_username = (payload.get("cognito:username") or "").strip() or None
+    user_id = payload.get("sub")
+    existing_profile = fetch_user_profile(user_id)
+    existing_name = (existing_profile.get("name") or "").strip() or None
+
     session["id_token"] = id_token
     session["access_token"] = tokens.get("access_token")
-    session["user_id"] = payload.get("sub")
+    session["user_id"] = user_id
     session["user_email"] = payload.get("email")
-    session["user_name"] = payload.get("name") or payload.get("cognito:username")
+    session["user_name"] = raw_name or existing_name or raw_username
 
     end = time.perf_counter()
     latency = (end - start) * 1000
@@ -186,10 +231,17 @@ def auth_callback() -> str:
     stored_name = sync_user_profile(
         session.get("user_id"),
         session.get("user_email"),
-        session.get("user_name"),
+        raw_name,
     )
     if stored_name:
         session["user_name"] = stored_name
+
+    if _looks_generated_display_name(
+        stored_name,
+        user_id=session.get("user_id"),
+        username=raw_username,
+    ):
+        return redirect(url_for("public.settings", require_display_name="1"))
 
     return redirect(url_for("public.landing_page"))
 

--- a/rowlytics_app/services/dynamodb.py
+++ b/rowlytics_app/services/dynamodb.py
@@ -81,13 +81,22 @@ def get_ddb_tables():
     return get_users_table(), get_team_members_table()
 
 
+def fetch_user_profile(user_id: str | None) -> dict:
+    if not user_id:
+        return {}
+
+    table = get_users_table()
+    response = table.get_item(Key={"userId": user_id})
+    return response.get("Item") or {}
+
+
 def sync_user_profile(user_id: str | None, email: str | None, name: str | None) -> str | None:
     if not user_id:
         logger.debug("sync_user_profile: no user_id provided")
         return name
     table = get_users_table()
 
-    safe_name = name or (email.split("@")[0] if email else "New Rower")
+    safe_name = name or "New Rower"
     now = now_iso()
 
     update_expr = (

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -1401,13 +1401,14 @@ body {
 /* Landing page (Startup)        */
 /* ============================= */
 
-.landing {
+main.landing {
   flex: 1;
   display: grid;
   place-items: center;
   text-align: center;
-
   padding: 3.5rem 1rem;
+  min-height: calc(100svh - 88px);
+  box-sizing: border-box;
 }
 
 .landing__hero {
@@ -1417,6 +1418,13 @@ body {
   gap: 2.25rem;
   width: 100%;
   max-width: 900px;
+}
+
+.landing__brand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
 }
 
 .landing__logo {
@@ -1539,5 +1547,73 @@ body {
 
   .notifications-dropdown__panel {
     width: 100%;
+  }
+
+  body.landing {
+    min-height: 100svh;
+    display: flex;
+    flex-direction: column;
+  }
+
+  main.landing {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    align-items: stretch;
+    padding: 1rem 1rem 1rem;
+  }
+
+  .landing__hero {
+    flex: 1;
+    justify-content: space-evenly;
+    gap: 1rem;
+    max-width: 100%;
+    padding-block: 0.5rem 1.05rem;
+  }
+
+  .landing__brand {
+    gap: 0.1rem;
+  }
+
+  .landing__logo {
+    width: min(60vw, 220px);
+    max-height: 122px;
+    margin-bottom: 0;
+  }
+
+  .landing__wordmark {
+    font-size: clamp(1.95rem, 9vw, 2.8rem);
+    line-height: 0.95;
+  }
+
+  .landing__actions {
+    width: 100%;
+    gap: 0.75rem;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .landing__btn {
+    min-width: 0;
+    width: 100%;
+    min-height: 50px;
+    font-size: 1rem;
+    padding: 0.75rem 1rem;
+  }
+
+  body.landing .footer {
+    margin-top: auto;
+    gap: 0.55rem;
+    padding: 0.7rem 1rem max(0.7rem, env(safe-area-inset-bottom));
+    font-size: 0.82rem;
+  }
+
+  body.landing .footer__socials,
+  body.landing .footer__links {
+    gap: 0.45rem 0.65rem;
+  }
+
+  body.landing .footer_version {
+    font-size: 0.72rem;
   }
 }

--- a/rowlytics_app/static/js/profile_modal.js
+++ b/rowlytics_app/static/js/profile_modal.js
@@ -1,9 +1,46 @@
 (() => {
   const modal = document.getElementById("profileModal");
   const triggers = document.querySelectorAll(".profile-link");
+  const nameValue = document.getElementById("profileNameValue");
+  const emailValue = document.getElementById("profileEmailValue");
+  const userIdValue = document.getElementById("profileUserIdValue");
   if (!modal || triggers.length === 0) return;
 
   const closeTriggers = modal.querySelectorAll("[data-profile-close]");
+  const apiBase = (document.body?.dataset?.apiBase || "").replace(/\/+$/, "");
+
+  const getApiUrl = (path) => {
+    if (apiBase) return apiBase + path;
+    const parts = window.location.pathname.split("/").filter(Boolean);
+    const first = parts[0];
+    const stage = first && ["Prod", "Stage", "Dev"].includes(first) ? `/${first}` : "";
+    return stage + path;
+  };
+
+  const setProfileValues = ({ name, email, userId }) => {
+    if (nameValue) {
+      nameValue.textContent = name || "Not set";
+    }
+    if (emailValue) {
+      emailValue.textContent = email || "Not set";
+    }
+    if (userIdValue) {
+      userIdValue.textContent = userId || "Not set";
+    }
+  };
+
+  const refreshProfile = async () => {
+    try {
+      const response = await fetch(getApiUrl("/api/account/profile"));
+      const data = await response.json();
+      if (!response.ok) {
+        return;
+      }
+      setProfileValues(data);
+    } catch (_error) {
+      // Keep the existing rendered values if the refresh fails.
+    }
+  };
 
   const openModal = () => {
     modal.setAttribute("aria-hidden", "false");
@@ -16,8 +53,9 @@
   };
 
   triggers.forEach((trigger) => {
-    trigger.addEventListener("click", (event) => {
+    trigger.addEventListener("click", async (event) => {
       event.preventDefault();
+      await refreshProfile();
       openModal();
     });
   });

--- a/rowlytics_app/static/js/settings.js
+++ b/rowlytics_app/static/js/settings.js
@@ -6,14 +6,35 @@
   const confirmWrap = document.getElementById("accountDeleteConfirm");
   const confirmBtn = document.getElementById("confirmDeleteAccount");
   const cancelBtn = document.getElementById("cancelDeleteAccount");
+  const apiBase = (document.body?.dataset?.apiBase || "").replace(/\/+$/, "");
+  const updateNameUrl = document.body?.dataset?.accountNameUrl || "";
+  const deleteAccountUrl = document.body?.dataset?.accountDeleteUrl || "";
+  const homeUrl = document.body?.dataset?.homeUrl || "/";
+  const signinUrl = document.body?.dataset?.signinUrl || "/signin";
+  const requireDisplayName = document.body?.dataset?.requireDisplayName === "true";
 
   if (!form || !nameInput || !message) return;
+
+  const getApiUrl = (path) => {
+    if (apiBase) return apiBase + path;
+    const parts = window.location.pathname.split("/").filter(Boolean);
+    const first = parts[0];
+    const stage = first && ["Prod", "Stage", "Dev"].includes(first) ? `/${first}` : "";
+    return stage + path;
+  };
 
   const setMessage = (text, tone) => {
     message.textContent = text;
     message.classList.remove("team-message--error", "team-message--success");
     if (tone === "error") message.classList.add("team-message--error");
     if (tone === "success") message.classList.add("team-message--success");
+  };
+
+  const updateProfileName = (name) => {
+    const profileNameValue = document.getElementById("profileNameValue");
+    if (profileNameValue) {
+      profileNameValue.textContent = name || "Not set";
+    }
   };
 
   form.addEventListener("submit", async (event) => {
@@ -24,19 +45,24 @@
       return;
     }
 
-    setMessage("Saving...", "info");
+      setMessage("Saving...", "info");
     try {
-      const response = await fetch("/api/account/name", {
+      const response = await fetch(updateNameUrl || getApiUrl("/api/account/name"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ name })
       });
       const data = await response.json();
       if (!response.ok) {
-        throw new Error(data.error || "Unable to update name");
+        throw new Error(data.detail || data.error || "Unable to update name");
       }
       nameInput.value = data.name || name;
+      updateProfileName(data.name || name);
       setMessage("Name updated.", "success");
+      if (requireDisplayName) {
+        window.location = homeUrl;
+        return;
+      }
     } catch (err) {
       setMessage(err.message || "Unable to update name", "error");
     }
@@ -59,15 +85,15 @@
       cancelBtn.disabled = true;
 
       try {
-        const response = await fetch("/api/account/delete", {
+        const response = await fetch(deleteAccountUrl || getApiUrl("/api/account/delete"), {
           method: "POST",
           headers: { "Content-Type": "application/json" }
         });
         const data = await response.json();
         if (!response.ok) {
-          throw new Error(data.error || "Unable to delete account");
+          throw new Error(data.detail || data.error || "Unable to delete account");
         }
-        window.location = "/signin";
+        window.location = signinUrl;
       } catch (err) {
         setMessage(err.message || "Unable to delete account", "error");
         confirmBtn.disabled = false;

--- a/rowlytics_app/templates/base.html
+++ b/rowlytics_app/templates/base.html
@@ -41,15 +41,15 @@
           <div class="profile-list">
             <div class="profile-item">
               <span class="profile-label">Name</span>
-              <span class="profile-value">{{ user_name or 'Not set' }}</span>
+              <span id="profileNameValue" class="profile-value">{{ user_name or 'Not set' }}</span>
             </div>
             <div class="profile-item">
               <span class="profile-label">Email</span>
-              <span class="profile-value">{{ user_email or 'Not set' }}</span>
+              <span id="profileEmailValue" class="profile-value">{{ user_email or 'Not set' }}</span>
             </div>
             <div class="profile-item">
               <span class="profile-label">User ID</span>
-              <span class="profile-value">{{ user_id or 'Not set' }}</span>
+              <span id="profileUserIdValue" class="profile-value">{{ user_id or 'Not set' }}</span>
             </div>
           </div>
 

--- a/rowlytics_app/templates/settings.html
+++ b/rowlytics_app/templates/settings.html
@@ -4,6 +4,15 @@
 
 {% block body_class %}capture account-settings{% endblock %}
 
+{% block body_attrs %}
+data-api-base="{{ request.url_root.rstrip('/') }}"
+data-account-name-url="{{ url_for('api.update_account_name') }}"
+data-account-delete-url="{{ url_for('api.delete_account') }}"
+data-home-url="{{ url_for('public.landing_page') }}"
+data-signin-url="{{ url_for('public.signin') }}"
+data-require-display-name="{{ 'true' if display_name_required else 'false' }}"
+{% endblock %}
+
 {% block header %}
   {% include "partials/masthead.html" %}
 {% endblock %}
@@ -14,6 +23,11 @@
     <div class="team-panel__header">
       <h2>Account Settings</h2>
       <p>Update your display name or delete your account.</p>
+      {% if display_name_required %}
+        <p class="team-message team-message--error">
+          Set your display name before continuing.
+        </p>
+      {% endif %}
     </div>
 
     <form id="accountNameForm" class="team-form">

--- a/rowlytics_app/templates/sign_in.html
+++ b/rowlytics_app/templates/sign_in.html
@@ -6,13 +6,15 @@
 {% block content %}
 <main class="landing">
   <section class="landing__hero">
-    <img
-      class="landing__logo"
-      src="{{ 'images/erg_cool.png' | cloudfront_url }}"
-      alt="Erglytics logo"
-    />
+    <div class="landing__brand">
+      <img
+        class="landing__logo"
+        src="{{ 'images/erg_cool.png' | cloudfront_url }}"
+        alt="Erglytics logo"
+      />
 
-    <h1 class="landing__wordmark">Erg-lytics</h1>
+      <h1 class="landing__wordmark">Erg-lytics</h1>
+    </div>
 
     <div class="landing__actions">
       {% if login_url %}
@@ -20,7 +22,7 @@
           Login
         </a>
 
-        <a class="btn btn--dark landing__btn" href="{{ login_url }}">
+        <a class="btn btn--dark landing__btn" href="{{ signup_url or login_url }}">
           Create Account
         </a>
       {% else %}

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -84,7 +84,7 @@ def test_sync_user_profile_returns_name_when_no_user_id(monkeypatch: pytest.Monk
     assert name == "Row Rower"
 
 
-def test_sync_user_profile_updates_with_email_and_derived_name(
+def test_sync_user_profile_updates_with_email_and_default_name(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     table = MagicMock()
@@ -102,7 +102,7 @@ def test_sync_user_profile_updates_with_email_and_derived_name(
     args, kwargs = table.update_item.call_args
     assert kwargs["Key"] == {"userId": "u1"}
     assert kwargs["UpdateExpression"] == update_expr
-    assert kwargs["ExpressionAttributeValues"][":name"] == "rower"
+    assert kwargs["ExpressionAttributeValues"][":name"] == "New Rower"
     assert kwargs["ExpressionAttributeValues"][":email"] == "rower@example.com"
 
 


### PR DESCRIPTION
This PR fixed the error we previously had where users couldn't change their display name. 
Along with this fix, I also changed how our signin/signup flows work because I thought they were a bit unintuitive. 
- The sign-in page now sends Create Account directly to Cognito signup
- The mobile landing layout was reworked so the logo/text/buttons/footer fit more cleanly on small screens
- New users are prompted to set a real display name immediately after signup when Cognito/default values are still in place.

I also fixed a few deployed-path issues caused by API Gateway stage prefixes. Account settings now use server-rendered API and redirect URLs. 

Finally, I updated the SAM/IAM config so Lambda can publish CloudWatch custom metrics and access the correct recovery DynamoDB tables in the deployed environment.

This PR resolves issue #163.

Please let me know if y'all have questions, or if there is stuff I should change up.
Also let me know what else I should add going into UAT.