### PR TITLE
samconfig.toml STANDARD set

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ sam deploy
 
 The deployment configuration is stored in 'samconfig.toml'.
 
+DO NOT change commit a different samconfig.toml unless there is an issue with the resources added currently. Maintain the repo samconfig.toml as the default. Change locally when deploying to a stack other than erglytics-dev and then do not include in git commits.
+
 Do *not deploy with ManageSharedResources as true*, unless you intend to create/rewrite the resources. It should be *false* on default.
 
 Be sure to *change the stack name to the correct stack* for your task (erglytics-dev, erglytics-version-..., erglytics-ui-test, etc.) to not overwrite incorrect stacks.

--- a/backend/samconfig.toml
+++ b/backend/samconfig.toml
@@ -7,7 +7,7 @@ s3_prefix = "erglytics-dev"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
 image_repositories = []
-parameter_overrides = "CognitoDomainPrefix=\"rowlytics-auth-recovery-20260314\" AppBaseUrl=\"https://xft207g10i.execute-api.us-east-2.amazonaws.com/Prod\" SesFromEmail=\"updates@erglytics.com\" UsersTableName=\"RowlyticsUsers\" TeamsTableName=\"RowlyticsTeams\" TeamMembersTableName=\"RowlyticsTeamMembers\" RecordingsTableName=\"RowlyticsRecordings\" WorkoutsTableName=\"RowlyticsWorkouts\" UploadBucketName=\"rowlyticsuploads\" UserPoolName=\"RowlyticsUserPool\" UserPoolClientName=\"RowlyticsUserPoolClient\" ManageSharedResources=\"false\" ExistingUserPoolId=\"us-east-2_jXENfSnPZ\" ExistingUserPoolClientId=\"2lu6fopujo3usd6qdt47nt3b20\""
+parameter_overrides = "CognitoDomainPrefix=\"rowlytics-auth-recovery-20260314\" AppBaseUrl=\"https://v353vlxck0.execute-api.us-east-2.amazonaws.com/Prod\" SesFromEmail=\"updates@erglytics.com\" SesTestTo=\"erglytics@gmail.com\" UsersTableName=\"RowlyticsUsersRecovery\" TeamsTableName=\"RowlyticsTeamsRecovery\" TeamMembersTableName=\"RowlyticsTeamMembersRecovery\" RecordingsTableName=\"RowlyticsRecordingsRecovery\" WorkoutsTableName=\"RowlyticsWorkoutsRecovery\" UploadBucketName=\"rowlyticsupload-recovery-793523315638\" UserPoolName=\"RowlyticsUserPool\" UserPoolClientName=\"RowlyticsUserPoolClient\" ManageSharedResources=\"false\" ExistingUserPoolId=\"us-east-2_jXENfSnPZ\" ExistingUserPoolClientId=\"2lu6fopujo3usd6qdt47nt3b20\""
 
 [default.global.parameters]
 region = "us-east-2"


### PR DESCRIPTION
Fixes bug and closes #139 

The samconfig needs a standard since when devs are deploying some of us are deploying with incorrect parameters (table names and baseapiurls) causing the stack to not work. When deploying with wrong table names, it doesn't work as it cannot find the tables. When deploying with the wrong apiurl, it doesn't work as after logging in instead of taking you to the stack's landing page, it redirects to the landing page of the stack who's apiurl you are inputting instead. 

This just creates a standard, and is specifically set to deploy to the dev stack with the currently correct parameters. Otherwise devs will just change the samconfig locally when deploy --guided to deploy to a different stack. They will NOT commit or open a PR with a new samconfig file unless it's specifically to change something wrong with the samconfig.