### PR TITLE
Ethics Stop 1: CV Bias Review

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ As a user rows, each stroke will be rated based on how far the user deviates fro
 ![Parts of Rowing Stroke](https://github.com/nwisnie/Erg-lytics/blob/main/rowlytics_app/static/images/super_stroker.png) <br><br>
 Right now, our plan is to have a score from 0 to 1 for the user’s hand/arm position *(should be straight during mid stroke for example)*, back position *(no slouching during the stroke start for example)*, and leg position *(should be straight during stroke completion for example)*. We plan to calculate each of these scores during all three portions of the stroke. When the rower finishes a workout, all of these scores will be tallied and the user will be able to see their total score, their average score for each portion of the stroke, and their average score for each body part.
 
+## CV Limitations, Assumptions and Ethical Notes
+Erglytics currently evaluates rowing posture using a side-view camera setup and compares detected body landmarks to an idealized stroke model. Because of this, even if the system says that your position is correct, results may be less reliable when:
+
+- the user is not fully visible from one side
+- the camera angle is not close to a side profile
+- lighting is poor or parts of the body are occluded
+- loose clothing, background clutter, or low video quality make landmarks hard to detect
+- the user’s body proportions, mobility, adaptive technique, or rowing style differ STRONGLY from the assumptions in the current model
+
+The scores should be treated as coaching assistance, not a medical diagnosis or safety advice. A lower score does not indicate immediately that the user is rowing incorrectly; it may reflect camera placement, visibility issues, or model limitations.
+
 ## Team-Centric Design
 Users are encouraged to take advantage of our team system by joining team! <br><br>
 Users on a team can either have the rower our coach status: <br>

--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -84,6 +84,7 @@ ALIGNMENT_ANCHOR_CANDIDATES = (
     "right_elbow",
     "nose",
 )
+# Current movement analysis assumes the user is captured primarily from one side.
 SIDE_PROFILE_LANDMARKS = {
     "left": (
         "left_shoulder",
@@ -102,6 +103,9 @@ SIDE_PROFILE_LANDMARKS = {
         "right_ankle",
     ),
 }
+# Landmarks below this visibility threshold are ignored.
+# This means lighting, clothing, body occlusion, camera quality, and framing
+# can disproportionately reduce usable data and degrade scoring reliability.
 MIN_VISIBILITY_FOR_ANALYSIS = 0.12
 MIN_STROKES_REQUIRED = 3
 MIN_RANGE_OF_MOTION = 0.12
@@ -192,6 +196,9 @@ def _smooth_coordinates(coordinates, alpha=0.35):
     return sorted(smoothed, key=lambda item: (item["time"], item["name"]))
 
 
+# Note: this heuristic picks the side with more detected landmarks, which works best
+# for a clean side-profile recording. It is less reliable for diagonal camera angles,
+# mirrored views, or partial visibility.
 def _detect_dominant_side(coordinates):
     counts = {}
     for side_name, landmark_names in SIDE_PROFILE_LANDMARKS.items():
@@ -268,6 +275,10 @@ def _compute_elbow_angle_normalized(shoulder, elbow, wrist):
         return None
 
 
+# Motion features are currently derived from upper-body landmark relationships.
+# This assumes the selected landmarks are visible and representative across users.
+# Differences in body proportions, adaptive rowing form, mobility limitations,
+# or non-standard technique may affect how well the current model generalizes.
 def _extract_motion_series_candidates(coordinates, dominant_side):
     wrist_name = f"{dominant_side}_wrist"
     elbow_name = f"{dominant_side}_elbow"

--- a/rowlytics_app/templates/capture_workout.html
+++ b/rowlytics_app/templates/capture_workout.html
@@ -29,9 +29,6 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
           />
           <p class="capture__placeholder-text">Keep one body side (shoulder to ankle) in frame</p>
           <p class="capture__note">
-            For best results, use a clear side view with your shoulder through ankle visible.
-          </p>
-          <p class="capture__note">
             Lighting, camera angle, loose clothing, or partial body visibility may reduce feedback's accuracy.
           </p>
           <p class="capture__note">

--- a/rowlytics_app/templates/capture_workout.html
+++ b/rowlytics_app/templates/capture_workout.html
@@ -28,6 +28,15 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
             alt="Rowing posture guide"
           />
           <p class="capture__placeholder-text">Keep one body side (shoulder to ankle) in frame</p>
+          <p class="capture__note">
+            For best results, use a clear side view with your shoulder through ankle visible.
+          </p>
+          <p class="capture__note">
+            Lighting, camera angle, loose clothing, or partial body visibility may reduce feedback's accuracy.
+          </p>
+          <p class="capture__note">
+            Feedback is meant to support coaching and practice, and may not fit every body type or rowing style equally well.
+          </p>
         </div>
         <video
           id="liveCamera"


### PR DESCRIPTION
Closes Issue #28 

This PR adds documentation, in-code comments, and minor UI changes to clarify the assumptions and current limitations of the computer vision workout analysis pipeline. The main focus was on identifying where the model relies on side-profile capture, landmark visibility thresholds, and idealized rowing form assumptions. 

Changes made:
- added documentation to the README that covers the limitations
- added user facing notes to the capture workout page
<img width="3839" height="2043" alt="image" src="https://github.com/user-attachments/assets/84b0daa4-b255-44a3-bb92-7549694d7790" />
<img width="2545" height="2054" alt="image" src="https://github.com/user-attachments/assets/5933b0dc-17b2-479f-a5fa-b57a2a97e806" />
- added comments in api_routes to document current assumptions