### PR TITLE
Improve Workout Summaries

### DIFF
--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -26,6 +26,7 @@ from rowlytics_app.services.dynamodb import (
     get_team,
     get_team_membership,
     get_teams_table,
+    get_workout_for_user,
     get_workouts_table,
     list_recordings,
     list_recordings_page,
@@ -1454,6 +1455,31 @@ def list_workouts_for_current_user():
         "userId": user_id,
         "workouts": items,
         "nextCursor": _encode_cursor(next_key),
+    })
+
+
+@api_bp.route("/workouts/<workout_id>", methods=["GET"])
+def get_workout_for_current_user(workout_id):
+    user_id = session.get("user_id")
+    if not user_id:
+        return jsonify({"error": "authentication required"}), 401
+
+    try:
+        workouts_table = get_workouts_table()
+    except RuntimeError as err:
+        return jsonify({"error": str(err)}), 500
+
+    try:
+        workout = get_workout_for_user(workouts_table, user_id, workout_id)
+    except Exception as err:
+        return jsonify({"error": "Unable to load workout", "detail": str(err)}), 500
+
+    if not workout:
+        return jsonify({"error": "Workout not found"}), 404
+
+    return jsonify({
+        "userId": user_id,
+        "workout": workout,
     })
 
 

--- a/rowlytics_app/routes.py
+++ b/rowlytics_app/routes.py
@@ -126,6 +126,15 @@ def template_detail(slug: str) -> str:
     return render_template(card.template_name, card=card, **user_context())
 
 
+@public_bp.route("/workout-summaries/<workout_id>")
+def workout_summary_detail(workout_id: str) -> str:
+    return render_template(
+        "workout_summary_detail.html",
+        workout_id=workout_id,
+        **user_context(),
+    )
+
+
 @public_bp.route("/profile")
 def profile() -> str:
     return render_template("profile.html", **user_context())

--- a/rowlytics_app/services/dynamodb.py
+++ b/rowlytics_app/services/dynamodb.py
@@ -77,6 +77,16 @@ def get_workouts_table():
     return _get_resource().Table(WORKOUTS_TABLE_NAME)
 
 
+def get_workout_for_user(workouts_table, user_id: str, workout_id: str):
+    response = workouts_table.get_item(
+        Key={
+            "userId": user_id,
+            "workoutId": workout_id,
+        }
+    )
+    return response.get("Item")
+
+
 def get_ddb_tables():
     return get_users_table(), get_team_members_table()
 

--- a/rowlytics_app/static/js/capture_workout.js
+++ b/rowlytics_app/static/js/capture_workout.js
@@ -1108,7 +1108,12 @@ async function saveWorkoutEntry(durationSec, startedAt, completedAt) {
     if (!response.ok) {
       throw new Error(payload.error || "Unable to save workout");
     }
+    const basePath = window.location.pathname.split("/").slice(0, 2).join("/");
     poseStatus.textContent = "Workout saved";
+    setTimeout(() => {
+      window.location.href = `${basePath}/workout-summaries/${payload.workoutId}`;
+    }, 500);
+
   } catch (err) {
     console.warn("Workout not saved:", err);
     poseStatus.textContent = "Workout ended (not saved)";

--- a/rowlytics_app/static/js/workout_summaries.js
+++ b/rowlytics_app/static/js/workout_summaries.js
@@ -140,8 +140,6 @@
       header.appendChild(title);
       header.appendChild(duration);
 
-      const summary = document.createElement("p");
-      summary.className = "workout-card__summary";
       const metrics = getWorkoutMetrics(workout);
 
       const score = document.createElement("p");
@@ -154,40 +152,13 @@
         score.textContent = `${Math.round(metrics.score)}% consistency`;
       }
 
-      summary.textContent = metrics.score == null
-        ? "Consistency score could not be calculated because not enough strokes were taken."
-        : metrics.summary;
-
-      const metricList = document.createElement("div");
-      metricList.className = "workout-card__metrics";
-      metricList.appendChild(buildMetricRow(
-        "Stroke count",
-        metrics.strokeCount == null ? "Not detected" : String(metrics.strokeCount),
-      ));
-      metricList.appendChild(buildMetricRow(
-        "Cadence",
-        metrics.cadenceSpm == null ? "Not available" : `${metrics.cadenceSpm.toFixed(1)} spm`,
-      ));
-      metricList.appendChild(buildMetricRow(
-        "Range of motion",
-        metrics.rangeOfMotion == null ? "Not available" : metrics.rangeOfMotion.toFixed(3),
-      ));
-
-      if (metrics.dominantSide) {
-        metricList.appendChild(buildMetricRow("Dominant side", metrics.dominantSide, true));
-      }
-      if (metrics.signalStrategy) {
-        metricList.appendChild(buildMetricRow(
-          "Signal",
-          metrics.signalStrategy.replaceAll("_", " "),
-          true,
-        ));
-      }
+      const preview = document.createElement("p");
+      preview.className = "workout-card__summary";
+      preview.textContent = "Click to view full workout summary →";
 
       card.appendChild(header);
       card.appendChild(score);
-      card.appendChild(summary);
-      card.appendChild(metricList);
+      card.appendChild(preview);
       grid.appendChild(card);
     });
   };

--- a/rowlytics_app/static/js/workout_summaries.js
+++ b/rowlytics_app/static/js/workout_summaries.js
@@ -120,6 +120,13 @@
       const card = document.createElement("article");
       card.className = "recording-card workout-card";
 
+      card.style.cursor = "pointer";
+
+      card.addEventListener("click", () => {
+        const basePath = window.location.pathname.split("/").slice(0, 2).join("/");
+        window.location.href = `${basePath}/workout-summaries/${workout.workoutId}`;
+      });
+
       const header = document.createElement("div");
       header.className = "workout-card__row";
       const title = document.createElement("h3");

--- a/rowlytics_app/static/js/workout_summary_detail.js
+++ b/rowlytics_app/static/js/workout_summary_detail.js
@@ -1,0 +1,68 @@
+(() => {
+  const container = document.getElementById("workoutDetail");
+  const message = document.getElementById("workoutDetailMessage");
+  const workoutId = document.body?.dataset?.workoutId;
+  const apiBase = (document.body?.dataset?.apiBase || "").replace(/\/+$/, "");
+
+  if (!container || !message || !workoutId) {
+    return;
+  }
+
+  const getApiUrl = (path) => {
+    if (apiBase) return apiBase + path;
+    const parts = window.location.pathname.split("/").filter(Boolean);
+    const first = parts[0];
+    const stage = first && ["Prod", "Stage", "Dev"].includes(first) ? `/${first}` : "";
+    return stage + path;
+  };
+
+  const formatDuration = (seconds) => {
+    if (!seconds && seconds !== 0) return "Unknown duration";
+    const total = Math.max(0, Math.round(seconds));
+    const mins = Math.floor(total / 60);
+    const secs = total % 60;
+    return mins ? `${mins}m ${secs}s` : `${secs}s`;
+  };
+
+  const loadWorkout = async () => {
+    message.textContent = "Loading workout...";
+    try {
+      const response = await fetch(getApiUrl(`/api/workouts/${workoutId}`));
+      const payload = await response.json();
+
+      if (!response.ok) {
+        throw new Error(payload.error || "Unable to load workout");
+      }
+
+      const workout = payload.workout;
+      const completedAt = new Date(workout.completedAt || workout.createdAt || Date.now()).toLocaleString();
+
+      container.innerHTML = `
+        <article class="recording-card workout-card">
+          <div class="workout-card__row">
+            <h1 class="workout-card__title">${completedAt}</h1>
+            <span class="workout-card__pill">${formatDuration(workout.durationSec)}</span>
+          </div>
+          <p class="workout-card__score">
+            ${workout.workoutScore != null ? `${Math.round(Number(workout.workoutScore))}% alignment` : "Score unavailable"}
+          </p>
+          <p class="workout-card__summary">${workout.summary || "No summary provided."}</p>
+          <div class="workout-card__metrics">
+            <p class="workout-card__metric"><span class="workout-card__metric-label">Stroke count:</span> <span class="workout-card__metric-value">${workout.strokeCount ?? "Not detected"}</span></p>
+            <p class="workout-card__metric"><span class="workout-card__metric-label">Cadence:</span> <span class="workout-card__metric-value">${workout.cadenceSpm ?? "Not available"}</span></p>
+            <p class="workout-card__metric"><span class="workout-card__metric-label">Range of motion:</span> <span class="workout-card__metric-value">${workout.rangeOfMotion ?? "Not available"}</span></p>
+            <p class="workout-card__metric workout-card__metric--subtle"><span class="workout-card__metric-label">Dominant side:</span> <span class="workout-card__metric-value">${workout.dominantSide || "Not available"}</span></p>
+          </div>
+          <pre class="workout-card__details">${workout.alignmentDetails || ""}</pre>
+        </article>
+      `;
+
+      message.textContent = "";
+    } catch (err) {
+      message.textContent = err.message || "Unable to load workout";
+      message.classList.add("recordings-message--error");
+    }
+  };
+
+  loadWorkout();
+})();

--- a/rowlytics_app/static/js/workout_summary_detail.js
+++ b/rowlytics_app/static/js/workout_summary_detail.js
@@ -24,6 +24,41 @@
     return mins ? `${mins}m ${secs}s` : `${secs}s`;
   };
 
+  const asNumber = (value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  const formatDecimal = (value, digits = 1) => {
+    const num = asNumber(value);
+    return num == null ? "Not available" : num.toFixed(digits);
+  };
+
+  const parseAlignmentDetails = (details) => {
+    const parsed = {};
+    (details || "")
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .forEach((line) => {
+        const separatorIndex = line.indexOf(":");
+        if (separatorIndex < 0) return;
+        const key = line.slice(0, separatorIndex).trim().toLowerCase();
+        const value = line.slice(separatorIndex + 1).trim();
+        parsed[key] = value;
+      });
+    return parsed;
+  };
+
+  const buildMetricRow = (label, value, subtle = false) => {
+    return `
+      <p class="workout-card__metric${subtle ? " workout-card__metric--subtle" : ""}">
+        <span class="workout-card__metric-label">${label}:</span>
+        <span class="workout-card__metric-value">${value}</span>
+      </p>
+    `;
+  };
+
   const loadWorkout = async () => {
     message.textContent = "Loading workout...";
     try {
@@ -35,29 +70,106 @@
       }
 
       const workout = payload.workout;
-      const completedAt = new Date(workout.completedAt || workout.createdAt || Date.now()).toLocaleString();
+      const details = parseAlignmentDetails(workout.alignmentDetails);
+
+      const completedAt = new Date(
+        workout.completedAt || workout.createdAt || Date.now(),
+      ).toLocaleString();
+
+      const score =
+        asNumber(workout.workoutScore) ??
+        asNumber(details["consistency score"]) ??
+        null;
+
+      const summary =
+        workout.summary ||
+        details.summary ||
+        "No summary provided.";
+
+      const strokeCount =
+        workout.strokeCount ??
+        details["stroke count"] ??
+        "Not detected";
+
+      const cadence =
+        workout.cadenceSpm != null
+          ? `${formatDecimal(workout.cadenceSpm, 1)} spm`
+          : details["cadence (spm)"] != null
+            ? `${formatDecimal(details["cadence (spm)"], 1)} spm`
+            : "Not available";
+
+      const rangeOfMotion =
+        workout.rangeOfMotion != null
+          ? formatDecimal(workout.rangeOfMotion, 3)
+          : details["range of motion"] != null
+            ? formatDecimal(details["range of motion"], 3)
+            : "Not available";
+
+      const dominantSide =
+        workout.dominantSide ||
+        details["dominant side"] ||
+        "Not available";
+
+      const signalUsed =
+        details["signal strategy"]
+          ? details["signal strategy"].replaceAll("_", " ")
+          : "Not available";
+
+      const movementGate =
+        details["movement gate"] || "Not available";
+
+      const movementReason =
+        details["movement reason"] || "Not available";
+
+      const clipsObserved =
+        details["clips observed"] || "Not available";
 
       container.innerHTML = `
-        <article class="recording-card workout-card">
-          <div class="workout-card__row">
-            <h1 class="workout-card__title">${completedAt}</h1>
-            <span class="workout-card__pill">${formatDuration(workout.durationSec)}</span>
-          </div>
-          <p class="workout-card__score">
-            ${workout.workoutScore != null ? `${Math.round(Number(workout.workoutScore))}% alignment` : "Score unavailable"}
-          </p>
-          <p class="workout-card__summary">${workout.summary || "No summary provided."}</p>
-          <div class="workout-card__metrics">
-            <p class="workout-card__metric"><span class="workout-card__metric-label">Stroke count:</span> <span class="workout-card__metric-value">${workout.strokeCount ?? "Not detected"}</span></p>
-            <p class="workout-card__metric"><span class="workout-card__metric-label">Cadence:</span> <span class="workout-card__metric-value">${workout.cadenceSpm ?? "Not available"}</span></p>
-            <p class="workout-card__metric"><span class="workout-card__metric-label">Range of motion:</span> <span class="workout-card__metric-value">${workout.rangeOfMotion ?? "Not available"}</span></p>
-            <p class="workout-card__metric workout-card__metric--subtle"><span class="workout-card__metric-label">Dominant side:</span> <span class="workout-card__metric-value">${workout.dominantSide || "Not available"}</span></p>
-          </div>
-          <pre class="workout-card__details">${workout.alignmentDetails || ""}</pre>
-        </article>
+        <div class="stack">
+          <article class="recording-card workout-card">
+            <div class="workout-card__row">
+              <h1 class="workout-card__title">${completedAt}</h1>
+              <span class="workout-card__pill">${formatDuration(workout.durationSec)}</span>
+            </div>
+
+            <p class="workout-card__score ${
+              score == null ? "workout-card__score--missing" : "workout-card__score--ok"
+            }">
+              ${score != null ? `${Math.round(score)}% consistency` : "Score unavailable"}
+            </p>
+
+            <p class="workout-card__summary">${summary}</p>
+
+            <div class="workout-card__metrics">
+              ${buildMetricRow("Stroke count", strokeCount)}
+              ${buildMetricRow("Cadence", cadence)}
+              ${buildMetricRow("Range of motion", rangeOfMotion)}
+              ${buildMetricRow("Dominant side", dominantSide, true)}
+            </div>
+
+            <div class="workout-card__metrics" style="margin-top: 1rem;">
+              ${buildMetricRow("Movement check", movementGate, true)}
+              ${buildMetricRow("Reason", movementReason, true)}
+              ${buildMetricRow("Signal used", signalUsed, true)}
+              ${buildMetricRow("Clips observed", clipsObserved, true)}
+            </div>
+          </article>
+
+          <section class="recording-card workout-card">
+            <div class="recordings-panel__header">
+              <h2>Snapshot Clips From This Workout</h2>
+              <p>Review the short clips captured during this workout session.</p>
+            </div>
+
+            <div id="workoutSnapshots" class="recordings-grid">
+              <div class="recordings-empty">Snapshot clips will appear here.</div>
+            </div>
+          </section>
+        </div>
       `;
 
       message.textContent = "";
+      message.classList.add("recordings-message--error");
     } catch (err) {
       message.textContent = err.message || "Unable to load workout";
       message.classList.add("recordings-message--error");

--- a/rowlytics_app/templates/workout_summary_detail.html
+++ b/rowlytics_app/templates/workout_summary_detail.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+
+{% block title %}Workout Summary{% endblock %}
+{% block body_class %}capture snapshot{% endblock %}
+
+{% block body_attrs %}
+data-user-id="{{ user_id }}"
+data-workout-id="{{ workout_id }}"
+data-api-base="{{ request.url_root.rstrip('/') }}"
+{% endblock %}
+
+{% block header %}
+  {% include "partials/masthead.html" %}
+{% endblock %}
+
+{% block content %}
+<main class="page page-pad">
+  <div class="container container--wide stack">
+    <section class="recordings-panel">
+      <a href="{{ url_for('public.template_detail', slug='workout-summaries') }}" class="btn btn--subtle">
+        Back to Workout Summaries
+      </a>
+
+      <div id="workoutDetail"></div>
+      <p id="workoutDetailMessage" class="recordings-message" aria-live="polite"></p>
+    </section>
+  </div>
+</main>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/workout_summary_detail.js') }}" defer></script>
+{% endblock %}

--- a/rowlytics_app/templates/workout_summary_detail.html
+++ b/rowlytics_app/templates/workout_summary_detail.html
@@ -17,10 +17,6 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
 <main class="page page-pad">
   <div class="container container--wide stack">
     <section class="recordings-panel">
-      <a href="{{ url_for('public.template_detail', slug='workout-summaries') }}" class="btn btn--subtle">
-        Back to Workout Summaries
-      </a>
-
       <div id="workoutDetail"></div>
       <p id="workoutDetailMessage" class="recordings-message" aria-live="polite"></p>
     </section>


### PR DESCRIPTION
Closes Issue #131 and #132 and starts prepping for #128 

This PR improves the workout summary detail page by making the main workout details easier to understand and beginning to combine the snapshot analysis and workout summary by adding a section at the bottom of the NEW workout summary detail page for the snapshots to go. This also makes the summary detail open immediately after the workout is finished, and reduces what is said on the library page for a cleaner layout. 

This has been deployed on the dev stack but here are some attached screenshots just in case.
<img width="3839" height="1956" alt="image" src="https://github.com/user-attachments/assets/91e5ac92-2d51-4441-b58e-30e7058c3f65" />
<img width="3839" height="1970" alt="image" src="https://github.com/user-attachments/assets/6d24ee25-d4c0-45e1-9f3c-8d8b7a12ac46" />