### PR TITLE
Noah ux suggestions 2

### DIFF
--- a/rowlytics_app/routes.py
+++ b/rowlytics_app/routes.py
@@ -171,6 +171,11 @@ def profile() -> str:
     return render_template("profile.html", **user_context())
 
 
+@public_bp.route("/help")
+def help_page() -> str:
+    return render_template("help.html", **user_context())
+
+
 @public_bp.route("/settings")
 def settings() -> str:
     return render_template(

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -720,6 +720,13 @@ body {
   box-shadow: none;
 }
 
+.workout-detail__back,
+.workout-detail__back:hover,
+.workout-detail__back:focus-visible {
+  color: var(--color-slate-900);
+  text-decoration: none;
+}
+
 .btn--danger {
   background: var(--color-danger);
 }
@@ -760,6 +767,65 @@ body {
 
   .capture__branding .logo-mark__text {
     max-width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  body.capture {
+    min-height: 100svh;
+    overflow-x: hidden;
+  }
+
+  body.capture .page-pad {
+    padding: 1rem 1rem 0.75rem;
+  }
+
+  .capture__main .container--wide {
+    max-width: 100%;
+    min-width: 0;
+  }
+
+  body.capture .stack {
+    width: 100%;
+    gap: 0.85rem;
+    min-width: 0;
+  }
+
+  .capture__frame {
+    width: 100%;
+    max-width: 100%;
+    max-height: 46svh;
+    min-width: 0;
+    padding: 1rem;
+  }
+
+  .capture__controls {
+    gap: 0.55rem;
+    width: 100%;
+    min-width: 0;
+  }
+
+  .capture__note {
+    font-size: 0.82rem;
+    line-height: 1.2;
+    max-width: 26rem;
+    margin-inline: auto;
+    width: 100%;
+  }
+
+  body.capture .footer {
+    gap: 0.55rem;
+    padding: 0.75rem 1rem max(0.75rem, env(safe-area-inset-bottom));
+    font-size: 0.82rem;
+  }
+
+  body.capture .footer__socials,
+  body.capture .footer__links {
+    gap: 0.45rem 0.65rem;
+  }
+
+  body.capture .footer_version {
+    font-size: 0.72rem;
   }
 }
 
@@ -1513,37 +1579,49 @@ main.landing {
   }
 
   .quadrants {
+    flex: 0 0 auto;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
-    padding: 1.25rem 1rem 2rem;
+    gap: 0.75rem;
+    padding: 1rem 0.85rem 1.5rem;
+    align-content: start;
+    align-items: stretch;
+    grid-auto-rows: 1fr;
   }
 
   .quadrant {
-    gap: 0.75rem;
-    padding: 1rem;
+    gap: 0.35rem;
+    padding: 0.6rem 0.45rem 0.65rem;
+    border-radius: 12px;
+    align-self: stretch;
+    height: 100%;
   }
 
   .quadrant img {
-    width: min(120px, 70%);
+    width: min(72px, 52%);
+    border-radius: 0;
   }
 
   .quadrant__copy {
+    flex: 0 1 auto;
     min-width: 0;
-    gap: 0.75rem;
+    gap: 0.35rem;
   }
 
   .quadrant__copy h2 {
-    font-size: 1rem;
+    font-size: 0.9rem;
+    line-height: 1.15;
   }
 
   .quadrant__copy p {
-    font-size: 0.9rem;
+    font-size: 0.78rem;
+    line-height: 1.25;
   }
 
   .quadrant__copy .btn {
     width: 100%;
     text-align: center;
-    padding: 0.7rem 1rem;
+    padding: 0.45rem 0.65rem;
+    font-size: 0.8rem;
   }
 
   .notifications-dropdown {

--- a/rowlytics_app/static/js/capture_workout.js
+++ b/rowlytics_app/static/js/capture_workout.js
@@ -13,6 +13,7 @@ const viewport = document.querySelector(".capture__viewport");
 const placeholder = document.getElementById("capturePlaceholder");
 const captureSessionNotice = document.getElementById("captureSessionNotice");
 const apiBase = (document.body?.dataset?.apiBase || "").replace(/\/+$/, "");
+const workoutDetailBase = document.body?.dataset?.workoutDetailBase || "";
 const urlParams = (() => {
   try {
     return new URLSearchParams(window.location.search || "");
@@ -1171,10 +1172,13 @@ async function saveWorkoutEntry(durationSec, startedAt, completedAt) {
     if (!response.ok) {
       throw new Error(payload.error || "Unable to save workout");
     }
-    const basePath = window.location.pathname.split("/").slice(0, 2).join("/");
     poseStatus.textContent = "Workout saved";
     setTimeout(() => {
-      window.location.href = `${basePath}/workout-summaries/${payload.workoutId}`;
+      const detailUrl = workoutDetailBase.replace("__WORKOUT_ID__", payload.workoutId);
+      const fallbackUrl = `/workout-summaries/${payload.workoutId}?captured=1`;
+      window.location.href = detailUrl
+        ? `${detailUrl}${detailUrl.includes("?") ? "&" : "?"}captured=1`
+        : fallbackUrl;
     }, 500);
 
   } catch (err) {

--- a/rowlytics_app/static/js/workout_summaries.js
+++ b/rowlytics_app/static/js/workout_summaries.js
@@ -5,6 +5,7 @@
   const message = document.getElementById("workoutsMessage");
   const loadMoreBtn = document.getElementById("workoutsLoadMore");
   const userId = document.body?.dataset?.userId;
+  const workoutDetailBase = document.body?.dataset?.workoutDetailBase || "";
 
   if (!grid || !message) return;
 
@@ -125,8 +126,8 @@
       card.style.cursor = "pointer";
 
       card.addEventListener("click", () => {
-        const basePath = window.location.pathname.split("/").slice(0, 2).join("/");
-        window.location.href = `${basePath}/workout-summaries/${workout.workoutId}`;
+        const detailUrl = workoutDetailBase.replace("__WORKOUT_ID__", workout.workoutId);
+        window.location.href = detailUrl || `/workout-summaries/${workout.workoutId}`;
       });
 
       const header = document.createElement("div");

--- a/rowlytics_app/static/js/workout_summary_detail.js
+++ b/rowlytics_app/static/js/workout_summary_detail.js
@@ -3,6 +3,14 @@
   const message = document.getElementById("workoutDetailMessage");
   const workoutId = document.body?.dataset?.workoutId;
   const apiBase = (document.body?.dataset?.apiBase || "").replace(/\/+$/, "");
+  const capturedFromWorkout = (() => {
+    try {
+      const params = new URLSearchParams(window.location.search || "");
+      return params.get("captured") === "1";
+    } catch (err) {
+      return false;
+    }
+  })();
 
   if (!container || !message || !workoutId) {
     return;
@@ -168,9 +176,15 @@
         </div>
       `;
 
-      message.textContent = "";
-      message.classList.add("recordings-message--error");
+      message.classList.remove("recordings-message--error", "recordings-message--success");
+      if (capturedFromWorkout) {
+        message.textContent = "Workout successfully captured.";
+        message.classList.add("recordings-message--success");
+      } else {
+        message.textContent = "";
+      }
     } catch (err) {
+      message.classList.remove("recordings-message--success");
       message.textContent = err.message || "Unable to load workout";
       message.classList.add("recordings-message--error");
     }

--- a/rowlytics_app/templates/capture_workout.html
+++ b/rowlytics_app/templates/capture_workout.html
@@ -7,6 +7,7 @@
 {% block body_attrs %}
 data-user-id="{{ user_id }}"
 data-api-base="{{ request.url_root.rstrip('/') }}"
+data-workout-detail-base="{{ url_for('public.workout_summary_detail', workout_id='__WORKOUT_ID__') }}"
 {% endblock %}
 
 {% block header %}
@@ -28,12 +29,6 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
             alt="Rowing posture guide"
           />
           <p class="capture__placeholder-text">Keep one body side (shoulder to ankle) in frame</p>
-          <p class="capture__note">
-            Lighting, camera angle, loose clothing, or partial body visibility may reduce feedback's accuracy.
-          </p>
-          <p class="capture__note">
-            Feedback is meant to support coaching and practice, and may not fit every body type or rowing style equally well.
-          </p>
         </div>
         <video
           id="liveCamera"

--- a/rowlytics_app/templates/help.html
+++ b/rowlytics_app/templates/help.html
@@ -16,12 +16,18 @@
       <p>Capture guidance and important notes for workout feedback.</p>
     </div>
 
-    <div class="team-panel__section">
+    <div class="team-panel__section team-panel__hint" style="font-weight: 400;">
       <p>
         Lighting, camera angle, loose clothing, or partial body visibility may reduce feedback's accuracy.
       </p>
       <p>
         Feedback is meant to support coaching and practice, and may not fit every body type or rowing style equally well.
+      </p>
+      <p>
+        For further instructions,
+        <a href="https://github.com/nwisnie/Erg-lytics/blob/main/doc/How-to.md" target="_blank" rel="noreferrer">
+          see our How-to guide
+        </a>.
       </p>
     </div>
   </section>

--- a/rowlytics_app/templates/help.html
+++ b/rowlytics_app/templates/help.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block title %}Help | Erglytics{% endblock %}
+
+{% block body_class %}capture account-settings{% endblock %}
+
+{% block header %}
+  {% include "partials/masthead.html" %}
+{% endblock %}
+
+{% block content %}
+<main class="page page-pad">
+  <section class="team-panel team-panel--centered container stack">
+    <div class="team-panel__header">
+      <h2>Help</h2>
+      <p>Capture guidance and important notes for workout feedback.</p>
+    </div>
+
+    <div class="team-panel__section">
+      <p>
+        Lighting, camera angle, loose clothing, or partial body visibility may reduce feedback's accuracy.
+      </p>
+      <p>
+        Feedback is meant to support coaching and practice, and may not fit every body type or rowing style equally well.
+      </p>
+    </div>
+  </section>
+</main>
+{% endblock %}

--- a/rowlytics_app/templates/partials/footer.html
+++ b/rowlytics_app/templates/partials/footer.html
@@ -8,7 +8,7 @@
     <p>Erglytics v0.6.2</p>
   </div>
   <div class="footer__links">
-    <a href="" target="_blank" rel="noreferrer">Help</a>
+    <a href="{{ url_for('public.help_page') }}">Help</a>
     <a href="" target="_blank" rel="noreferrer">Resources</a>
     <a href="https://github.com/nwisnie/Rowlytics" target="_blank" rel="noreferrer">GitHub</a>
   </div>

--- a/rowlytics_app/templates/partials/masthead.html
+++ b/rowlytics_app/templates/partials/masthead.html
@@ -31,15 +31,6 @@
         </div>
       </div>
 
-      <button
-        class="icon-btn"
-        type="button"
-        aria-label="Back"
-        onclick="if (window.history.length > 1) { history.back(); } else { window.location.href='{{ url_for('public.landing_page') }}'; }"
-      >
-        <img class="icon-btn__img" src="{{ 'images/back_cool.png' | cloudfront_url }}" alt="" />
-      </button>
-
       <a class="icon-btn" href="{{ url_for('public.landing_page') }}" aria-label="Home">
         <img class="icon-btn__img" src="{{ 'images/home_coolV2.png' | cloudfront_url }}" alt="" />
       </a>
@@ -47,10 +38,6 @@
       {% if user_id %}
         <a class="icon-btn profile-link" href="{{ url_for('public.profile') }}" aria-label="Profile">
           <img class="icon-btn__img" src="{{ 'images/profile_cool.png' | cloudfront_url }}" alt="" />
-        </a>
-
-        <a class="icon-btn" href="{{ url_for('public.settings') }}" aria-label="Settings">
-          <img class="icon-btn__img" src="{{ 'images/settings_cool.png' | cloudfront_url }}" alt="" />
         </a>
       {% else %}
         <a class="icon-btn" href="{{ url_for('public.signin') }}" aria-label="Sign in">

--- a/rowlytics_app/templates/workout_summaries.html
+++ b/rowlytics_app/templates/workout_summaries.html
@@ -7,6 +7,7 @@
 {% block body_attrs %}
 data-user-id="{{ user_id }}"
 data-api-base="{{ request.url_root.rstrip('/') }}"
+data-workout-detail-base="{{ url_for('public.workout_summary_detail', workout_id='__WORKOUT_ID__') }}"
 {% endblock %}
 
 {% block header %}

--- a/rowlytics_app/templates/workout_summary_detail.html
+++ b/rowlytics_app/templates/workout_summary_detail.html
@@ -15,10 +15,17 @@ data-api-base="{{ request.url_root.rstrip('/') }}"
 
 {% block content %}
 <main class="page page-pad">
+  <div class="container container--wide" style="margin-bottom: 0.75rem;">
+    <p id="workoutDetailMessage" class="recordings-message" aria-live="polite"></p>
+  </div>
+  <div class="container container--wide" style="margin-bottom: 1rem;">
+    <a class="btn btn--subtle workout-detail__back" href="{{ url_for('public.template_detail', slug='workout-summaries') }}">
+      Back to Workout Summaries
+    </a>
+  </div>
   <div class="container container--wide stack">
     <section class="recordings-panel">
       <div id="workoutDetail"></div>
-      <p id="workoutDetailMessage" class="recordings-message" aria-live="polite"></p>
     </section>
   </div>
 </main>


### PR DESCRIPTION
This PR adds several of the fixes suggested by Prof France during our last meeting.

To start, I fixed our capture workout page to better fit on mobile and moved some of the text that was in the capture workout box to the help page so it looks less visually cluttered. Also, after a workout is captured, the user is immediately taken to the workout summary detail page for the workout they just recorded. I also added a back button on that summary detail page and a "workout is captured successfully" notification that only shows up after they are taken to the summary detail from the capture workout page. I also fixed our main page on mobile so more icons fit on the screen at a time. A final thing to note is that I removed a few of the icons on the top bar as per suggestions from prof France. Here are screenshots of those pages as well as the new help page.

<img width="377" height="668" alt="image" src="https://github.com/user-attachments/assets/7c3daed3-6f30-4d95-af1c-8aaa17f9e994" />

<img width="372" height="667" alt="image" src="https://github.com/user-attachments/assets/9932ae4a-c1ec-4d5f-be9b-6ade4d9b9629" />

<img width="372" height="667" alt="image" src="https://github.com/user-attachments/assets/e751eb87-2a78-41c4-a374-fa200fab92d2" />

<img width="375" height="667" alt="image" src="https://github.com/user-attachments/assets/ab140093-1c96-4947-84a7-1470cdd3f3f5" />


This PR partially resolves issue #148.
This PR resolves issue #146.

These changes were deployed to erglyitcs-UAT if you want to test them.

Let me know if y'all have questions or if I should add more