### PR TITLE
can now add to team with display name + misc UI fixes

### DIFF
--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -36,6 +36,7 @@ from rowlytics_app.services.dynamodb import (
     list_workouts_page,
     normalize_display_name,
     now_iso,
+    resolve_user_by_identifier,
     team_name_exists,
 )
 from rowlytics_app.services.s3 import UPLOAD_BUCKET_NAME, get_s3_client
@@ -782,9 +783,9 @@ def add_team_member(team_id):
         return jsonify({"error": "team_id is required"}), 400
 
     data = request.get_json(silent=True) or {}
-    user_id = (data.get("userId") or "").strip()
-    if not user_id:
-        return jsonify({"error": "userId is required"}), 400
+    user_identifier = (data.get("userLookup") or data.get("userId") or "").strip()
+    if not user_identifier:
+        return jsonify({"error": "display name or user ID is required"}), 400
 
     member_role = (data.get("memberRole") or "rower").strip()
     member_role = member_role.lower()
@@ -799,11 +800,17 @@ def add_team_member(team_id):
         return jsonify({"error": str(err)}), 500
 
     try:
-        user_response = users_table.get_item(Key={"userId": user_id})
+        user_item = resolve_user_by_identifier(users_table, user_identifier)
+    except ValueError as err:
+        return jsonify({"error": str(err)}), 409
     except Exception as err:
         return jsonify({"error": "Unable to verify user", "detail": str(err)}), 500
 
-    if not user_response.get("Item"):
+    if not user_item:
+        return jsonify({"error": "User does not exist"}), 404
+
+    user_id = user_item.get("userId")
+    if not user_id:
         return jsonify({"error": "User does not exist"}), 404
 
     try:

--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -26,12 +26,14 @@ from rowlytics_app.services.dynamodb import (
     get_ddb_tables,
     get_recordings_table,
     get_team,
+    get_team_by_name,
     get_team_membership,
     get_teams_table,
     get_workout_for_user,
     get_workouts_table,
     list_recordings,
     list_recordings_page,
+    list_team_members_by_team,
     list_team_memberships,
     list_workouts_page,
     normalize_display_name,
@@ -867,6 +869,7 @@ def current_team():
 
     try:
         users_table, team_members_table = get_ddb_tables()
+        teams_table = get_teams_table()
     except RuntimeError as err:
         logger.error(f"GET /team/current: DynamoDB tables not available: {err}")
         return jsonify({"error": str(err)}), 500
@@ -884,6 +887,12 @@ def current_team():
 
     team_id = membership.get("teamId")
     logger.debug(f"GET /team/current: user {user_id} is on team {team_id}")
+
+    try:
+        team = get_team(teams_table, team_id)
+    except Exception as err:
+        logger.error(f"GET /team/current: failed to load team metadata: {err}", exc_info=True)
+        return jsonify({"error": "Unable to load team", "detail": str(err)}), 500
 
     try:
         members, next_key = fetch_team_members_page(
@@ -905,6 +914,7 @@ def current_team():
 
     return jsonify({
         "teamId": team_id,
+        "teamName": (team or {}).get("teamName"),
         "members": members,
         "memberRole": membership.get("memberRole"),
         "nextCursor": _encode_cursor(next_key),
@@ -918,9 +928,9 @@ def join_team():
         return jsonify({"error": "authentication required"}), 401
 
     data = request.get_json(silent=True) or {}
-    team_id = (data.get("teamId") or "").strip()
-    if not team_id:
-        return jsonify({"error": "teamId is required"}), 400
+    team_name = (data.get("teamName") or "").strip()
+    if not team_name:
+        return jsonify({"error": "teamName is required"}), 400
 
     member_role = (data.get("memberRole") or "rower").strip().lower()
     if member_role not in ALLOWED_TEAM_ROLES:
@@ -934,9 +944,10 @@ def join_team():
     except RuntimeError as err:
         return jsonify({"error": str(err)}), 500
 
-    team_item = get_team(teams_table, team_id)
+    team_item = get_team_by_name(teams_table, team_name)
     if not team_item:
         return jsonify({"error": "Team not found"}), 404
+    team_id = team_item.get("teamId")
 
     try:
         existing = get_team_membership(team_members_table, user_id)
@@ -1086,6 +1097,7 @@ def leave_team():
 
     try:
         _, team_members_table = get_ddb_tables()
+        teams_table = get_teams_table()
     except RuntimeError as err:
         return jsonify({"error": str(err)}), 500
 
@@ -1099,11 +1111,26 @@ def leave_team():
 
     team_id = membership.get("teamId")
     try:
+        team_members = list_team_members_by_team(team_members_table, team_id)
+    except Exception as err:
+        return jsonify({"error": "Unable to inspect team members", "detail": str(err)}), 500
+
+    deleted_team = len(team_members) <= 1
+    try:
         team_members_table.delete_item(Key={"teamId": team_id, "userId": user_id})
     except Exception as err:
         return jsonify({"error": "Unable to leave team", "detail": str(err)}), 500
 
-    return jsonify({"status": "ok", "teamId": team_id})
+    if deleted_team:
+        try:
+            teams_table.delete_item(Key={"teamId": team_id})
+        except Exception as err:
+            return jsonify({
+                "error": "Left team but failed to delete empty team",
+                "detail": str(err),
+            }), 500
+
+    return jsonify({"status": "ok", "teamId": team_id, "deletedTeam": deleted_team})
 
 
 @api_bp.route("/account/name", methods=["POST"])

--- a/rowlytics_app/services/dynamodb.py
+++ b/rowlytics_app/services/dynamodb.py
@@ -524,6 +524,37 @@ def team_name_exists(teams_table, team_name: str) -> bool:
     return bool(response.get("Items"))
 
 
+def get_team_by_name(teams_table, team_name: str) -> dict | None:
+    if not team_name:
+        return None
+
+    if Attr is None:
+        raise RuntimeError("boto3 is required for DynamoDB access")
+
+    try:
+        response = teams_table.query(
+            IndexName=TEAM_NAME_INDEX,
+            KeyConditionExpression=Key("teamName").eq(team_name),
+            Limit=1,
+        )
+        items = response.get("Items") or []
+        if items:
+            return items[0]
+    except Exception as err:
+        if ClientError and isinstance(err, ClientError):
+            error_code = err.response.get("Error", {}).get("Code")
+            if error_code not in {"ValidationException", "ResourceNotFoundException"}:
+                raise
+        else:
+            raise
+
+    items = scan_all(
+        teams_table,
+        FilterExpression=Attr("teamName").eq(team_name),
+    )
+    return items[0] if items else None
+
+
 def display_name_exists(
     users_table,
     display_name: str,

--- a/rowlytics_app/services/dynamodb.py
+++ b/rowlytics_app/services/dynamodb.py
@@ -564,3 +564,59 @@ def display_name_exists(
         if item.get("nameKey") == normalized_name:
             return True
     return False
+
+
+def resolve_user_by_identifier(users_table, identifier: str) -> dict | None:
+    identifier = (identifier or "").strip()
+    if not identifier:
+        return None
+
+    try:
+        response = users_table.get_item(Key={"userId": identifier})
+    except Exception:
+        raise
+
+    item = response.get("Item")
+    if item:
+        return item
+
+    normalized_name = normalize_display_name(identifier)
+    if not normalized_name:
+        return None
+
+    matches = []
+    try:
+        response = users_table.query(
+            IndexName=USERS_NAME_INDEX,
+            KeyConditionExpression=Key("nameKey").eq(normalized_name),
+            Limit=10,
+        )
+        matches = response.get("Items", [])
+    except Exception as err:
+        if ClientError and isinstance(err, ClientError):
+            error_code = err.response.get("Error", {}).get("Code")
+            if error_code not in {"ValidationException", "ResourceNotFoundException"}:
+                raise
+        else:
+            raise
+
+    if not matches:
+        matches = [
+            item
+            for item in scan_all(users_table)
+            if (
+                item.get("nameKey") == normalized_name
+                or normalize_display_name(item.get("name")) == normalized_name
+            )
+        ]
+
+    unique_matches = {
+        item.get("userId"): item
+        for item in matches
+        if item.get("userId")
+    }
+    if not unique_matches:
+        return None
+    if len(unique_matches) > 1:
+        raise ValueError("Multiple users found with that display name. Use a user ID instead.")
+    return next(iter(unique_matches.values()))

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -417,29 +417,46 @@ body {
   box-shadow: var(--btn-hover-shadow);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .quadrant {
     flex-direction: column;
     text-align: center;
+    height: 100%;
+    gap: 0.75rem;
+    padding: 1rem 0.9rem;
   }
 
   .quadrant img {
-    width: min(240px, 80%);
+    width: min(120px, 52%);
     height: auto;
   }
 
   .quadrant__copy {
     align-items: center;
+    flex: 0 1 auto;
+    min-width: 0;
+    gap: 0.65rem;
   }
 
   .quadrant__copy .btn {
     align-self: center;
+    width: 100%;
+    text-align: center;
+    padding: 0.65rem 0.9rem;
   }
 }
 
 @media (max-width: 1100px) {
   .quadrants {
+    flex: 0 0 auto;
     grid-template-columns: repeat(2, minmax(280px, 1fr));
+    align-content: start;
+    align-items: stretch;
+    grid-auto-rows: 1fr;
+  }
+
+  .quadrant {
+    align-self: stretch;
   }
 }
 

--- a/rowlytics_app/static/js/team_view.js
+++ b/rowlytics_app/static/js/team_view.js
@@ -217,9 +217,9 @@
       return;
     }
 
-    const userId = memberUserId.value.trim();
-    if (!userId) {
-      setMessage("Enter a user ID to add.", "error");
+    const userLookup = memberUserId.value.trim();
+    if (!userLookup) {
+      setMessage("Enter a display name or user ID to add.", "error");
       return;
     }
 
@@ -229,7 +229,7 @@
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
-          userId,
+          userLookup,
           memberRole: memberRole.value,
           joinedAt: new Date().toISOString(),
         }),

--- a/rowlytics_app/static/js/team_view.js
+++ b/rowlytics_app/static/js/team_view.js
@@ -29,6 +29,7 @@
   }
 
   let currentTeamId = null;
+  let currentTeamName = null;
   let nextMembersCursor = null;
   let members = [];
   let loadingMembers = false;
@@ -82,17 +83,19 @@
     activeSection.classList.add("team-panel__section--hidden");
     teamStatus.textContent = "You're not on a team yet.";
     currentTeamId = null;
+    currentTeamName = null;
     members = [];
     renderMembers();
     setLoadMoreState(null);
   };
 
-  const showActive = (teamId, incomingMembers, nextCursor, append) => {
+  const showActive = (teamId, teamName, incomingMembers, nextCursor, append) => {
     joinSection.classList.add("team-panel__section--hidden");
     activeSection.classList.remove("team-panel__section--hidden");
     teamStatus.textContent = "You're on a team.";
-    teamIdDisplay.textContent = `Team ID: ${teamId}`;
+    teamIdDisplay.textContent = teamName ? `Team name: ${teamName}` : `Team ID: ${teamId}`;
     currentTeamId = teamId;
+    currentTeamName = teamName || null;
     members = append ? members.concat(incomingMembers) : incomingMembers;
     renderMembers();
     setLoadMoreState(nextCursor);
@@ -126,7 +129,7 @@
         return;
       }
 
-      showActive(data.teamId, data.members || [], data.nextCursor, append);
+      showActive(data.teamId, data.teamName, data.members || [], data.nextCursor, append);
     } catch (err) {
       if (!append) {
         showJoin();
@@ -140,9 +143,9 @@
 
   joinForm.addEventListener("submit", async (event) => {
     event.preventDefault();
-    const teamId = joinInput.value.trim();
-    if (!teamId) {
-      setMessage("Enter a team ID to join.", "error");
+    const teamName = joinInput.value.trim();
+    if (!teamName) {
+      setMessage("Enter a team name to join.", "error");
       return;
     }
 
@@ -151,7 +154,7 @@
       const response = await fetch(getApiUrl("/api/team/join"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ teamId }),
+        body: JSON.stringify({ teamName }),
       });
       const data = await response.json();
       if (!response.ok) {
@@ -186,7 +189,7 @@
           throw new Error(data.error || "Unable to create team");
         }
         createInput.value = "";
-        setMessage("Team created. Share the Team ID to invite members.", "success");
+        setMessage("Team created. Share the team name to invite members.", "success");
         await loadCurrentTeam();
       } catch (err) {
         setMessage(err.message || "Unable to create team", "error");
@@ -196,6 +199,15 @@
 
   teamLeaveBtn.addEventListener("click", async () => {
     if (!currentTeamId) return;
+    const leavingDeletesTeam = members.length === 1 && !nextMembersCursor;
+    if (leavingDeletesTeam) {
+      const confirmed = window.confirm(
+        `You are the last member of ${currentTeamName || "this team"}. Leaving will delete the team. Continue?`,
+      );
+      if (!confirmed) {
+        return;
+      }
+    }
     setMessage("Leaving team...", "info");
     try {
       const response = await fetch(getApiUrl("/api/team/leave"), { method: "DELETE" });
@@ -203,7 +215,7 @@
       if (!response.ok) {
         throw new Error(data.error || "Unable to leave team");
       }
-      setMessage("Left team.", "success");
+      setMessage(data.deletedTeam ? "Left team. The empty team was deleted." : "Left team.", "success");
       showJoin();
     } catch (err) {
       setMessage(err.message || "Unable to leave team", "error");

--- a/rowlytics_app/templates/partials/footer.html
+++ b/rowlytics_app/templates/partials/footer.html
@@ -1,15 +1,15 @@
 <footer class="footer">
   <div class="footer__socials">
-    <a href="" target="_blank" rel="noreferrer">Twitter</a>
-    <a href="" target="_blank" rel="noreferrer">Instagram</a>
-    <a href="" target="_blank" rel="noreferrer">LinkedIn</a>
+    <a aria-disabled="true">Twitter</a>
+    <a aria-disabled="true">Instagram</a>
+    <a aria-disabled="true">LinkedIn</a>
   </div>
   <div class="footer_version">
     <p>Erglytics v0.6.2</p>
   </div>
   <div class="footer__links">
     <a href="{{ url_for('public.help_page') }}">Help</a>
-    <a href="" target="_blank" rel="noreferrer">Resources</a>
+    <a href="https://github.com/nwisnie/Erg-lytics/tree/main/doc" target="_blank" rel="noreferrer">Resources</a>
     <a href="https://github.com/nwisnie/Rowlytics" target="_blank" rel="noreferrer">GitHub</a>
   </div>
 </footer>

--- a/rowlytics_app/templates/team_view.html
+++ b/rowlytics_app/templates/team_view.html
@@ -71,12 +71,12 @@
 
           <h3>Add Member</h3>
           <form id="teamAddForm" class="team-form">
-            <label class="team-form__label" for="memberUserId">User ID</label>
+            <label class="team-form__label" for="memberUserId">Display Name or User ID</label>
             <input
               id="memberUserId"
               class="team-form__input"
               type="text"
-              placeholder="cognito-sub-uuid"
+              placeholder="Display name or user ID"
               required
             />
 

--- a/rowlytics_app/templates/team_view.html
+++ b/rowlytics_app/templates/team_view.html
@@ -18,15 +18,15 @@
 
         <section id="teamJoinSection" class="team-panel__section">
           <h3>Join a team</h3>
-          <p class="team-panel__hint">Enter a team ID to get started.</p>
+          <p class="team-panel__hint">Enter a team name to get started.</p>
           <form id="teamJoinForm" class="team-form">
-            <label class="team-form__label" for="teamJoinId">Team ID</label>
+            <label class="team-form__label" for="teamJoinId">Team name</label>
             <div class="team-form__row">
               <input
                 id="teamJoinId"
                 class="team-form__input"
                 type="text"
-                placeholder="team-1234"
+                placeholder="Erglytics Varsity"
                 required
               />
               <button class="btn" type="submit">Join team</button>
@@ -34,7 +34,7 @@
           </form>
 
           <h3>Create a team</h3>
-          <p class="team-panel__hint">Pick a name and we will generate a Team ID.</p>
+          <p class="team-panel__hint">Pick a unique team name that others can use to join.</p>
           <form id="teamCreateForm" class="team-form">
             <label class="team-form__label" for="teamCreateName">Team name</label>
             <div class="team-form__row">

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -420,6 +420,40 @@ def test_display_name_exists_reraises_unexpected_client_error() -> None:
         dynamodb.display_name_exists(users_table, "Rower")
 
 
+def test_resolve_user_by_identifier_returns_direct_user_id_match() -> None:
+    users_table = MagicMock()
+    users_table.get_item.return_value = {"Item": {"userId": "u1", "name": "Rower"}}
+
+    result = dynamodb.resolve_user_by_identifier(users_table, "u1")
+
+    assert result == {"userId": "u1", "name": "Rower"}
+    users_table.query.assert_not_called()
+
+
+def test_resolve_user_by_identifier_returns_display_name_match() -> None:
+    users_table = MagicMock()
+    users_table.get_item.return_value = {}
+    users_table.query.return_value = {"Items": [{"userId": "u2", "name": "Boat Mover"}]}
+
+    result = dynamodb.resolve_user_by_identifier(users_table, "Boat Mover")
+
+    assert result == {"userId": "u2", "name": "Boat Mover"}
+
+
+def test_resolve_user_by_identifier_raises_for_multiple_display_name_matches() -> None:
+    users_table = MagicMock()
+    users_table.get_item.return_value = {}
+    users_table.query.return_value = {
+        "Items": [
+            {"userId": "u2", "name": "Boat Mover"},
+            {"userId": "u3", "name": "Boat Mover"},
+        ]
+    }
+
+    with pytest.raises(ValueError):
+        dynamodb.resolve_user_by_identifier(users_table, "Boat Mover")
+
+
 def test_query_all_returns_empty_list(monkeypatch: pytest.MonkeyPatch) -> None:
     table = MagicMock()
     table.query.return_value = {"Items": []}


### PR DESCRIPTION
This PR adds more UX fixes from Prof France's suggestions during our most recent meeting.
- teams can now add rowers to a team by their display name or user id which is much more intuitive (was originally just their super long user id)
- users can now join a team by using team name (not just team id) which again is much more intuitive to users
- If a user leaves a team and they were the last member on the team, that team gets deleted (fixes orphan team issue)
- I also fixed the browser UI so that the icon tiles are better scaled when the browser is partially minimized.
- I also made the links that don't do anything just link do nothing now.

This PR mostly closes issue #148, we just need to fix the clip recording issue, but that is more minor since the hard limit of 3 clips was imposed as just a temp change to make sure people don't run up our S3 costs during UAT.

This PR also closes issue #129 (orphaned team issue)

The changes from this PR were deployed to erglytics-UAT if you want to test.