### PR TITLE
Add Custom Domain Support for Stacks

### DIFF
--- a/backend/samconfig.toml
+++ b/backend/samconfig.toml
@@ -7,7 +7,7 @@ s3_prefix = "erglytics-dev"
 confirm_changeset = true
 capabilities = "CAPABILITY_IAM"
 image_repositories = []
-parameter_overrides = "CognitoDomainPrefix=\"rowlytics-auth-recovery-20260314\" AppBaseUrl=\"https://v353vlxck0.execute-api.us-east-2.amazonaws.com/Prod\" SesFromEmail=\"updates@erglytics.com\" SesTestTo=\"erglytics@gmail.com\" UsersTableName=\"RowlyticsUsersRecovery\" TeamsTableName=\"RowlyticsTeamsRecovery\" TeamMembersTableName=\"RowlyticsTeamMembersRecovery\" RecordingsTableName=\"RowlyticsRecordingsRecovery\" WorkoutsTableName=\"RowlyticsWorkoutsRecovery\" UploadBucketName=\"rowlyticsupload-recovery-793523315638\" UserPoolName=\"RowlyticsUserPool\" UserPoolClientName=\"RowlyticsUserPoolClient\" ManageSharedResources=\"false\" ExistingUserPoolId=\"us-east-2_jXENfSnPZ\" ExistingUserPoolClientId=\"2lu6fopujo3usd6qdt47nt3b20\""
+parameter_overrides = "CognitoDomainPrefix=\"rowlytics-auth-recovery-20260314\" CognitoHostedUiDomain=\"auth.erglytics.com\" AppBaseUrl=\"https://dev.erglytics.com\" SesFromEmail=\"updates@erglytics.com\" SesTestTo=\"erglytics@gmail.com\" UsersTableName=\"RowlyticsUsersRecovery\" TeamsTableName=\"RowlyticsTeamsRecovery\" TeamMembersTableName=\"RowlyticsTeamMembersRecovery\" RecordingsTableName=\"RowlyticsRecordingsRecovery\" WorkoutsTableName=\"RowlyticsWorkoutsRecovery\" UploadBucketName=\"rowlyticsupload-recovery-793523315638\" UserPoolName=\"RowlyticsUserPool\" UserPoolClientName=\"RowlyticsUserPoolClient\" ManageSharedResources=\"false\" ExistingUserPoolId=\"us-east-2_jXENfSnPZ\" ExistingUserPoolClientId=\"2lu6fopujo3usd6qdt47nt3b20\""
 
 [default.global.parameters]
 region = "us-east-2"

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -16,8 +16,8 @@ Parameters:
 
   AppBaseUrl:
     Type: String
-    Default: https://xft207g10i.execute-api.us-east-2.amazonaws.com/Prod
-    Description: Base URL used for Cognito callback and logout redirects.
+    Default: https://dev.erglytics.com
+    Description: Public URL for this stack used for Cognito callback urls.
 
   SesFromEmail:
     Type: String
@@ -483,5 +483,8 @@ Outputs:
     Value: !If [CreateManagedResources, !Ref UserPoolClient, !Ref ExistingUserPoolClientId]
   UserPoolDomain:
     Value: !Ref CognitoHostedUiDomain
+  ErglyticsAppUrl:
+    Description: Public application URL
+    Value: !Ref AppBaseUrl
   RowlyticsApiUrl:
     Value: !Sub "https://${RowlyticsApi}.execute-api.${AWS::Region}.amazonaws.com/Prod"

--- a/doc/domain_setup.md
+++ b/doc/domain_setup.md
@@ -1,0 +1,184 @@
+# Custom Domain Setup Guide (API Gateway + Cognito)
+
+This document details how our custom domains are configured for our multistack setup.
+
+---
+
+## Overview
+
+We use custom subdomains instead of raw API Gateway URLS for cleaner and easier access.
+
+Right now we have a certificate for *.erglytics.com, so anything one level above erglytics is covered (does not cover things like stack.one.erglytics.com).
+
+Each stack should have its own subdomain. As of right now, we CANNOT have the same subdomain apply to multiple stacks.
+
+---
+
+## Domain Structure
+
+*Add as you create subdomains for new stacks*
+
+| Environment | Domain |
+|---|---|
+| Main Version (0-6-2) | `app.erglytics.com` |
+| Dev Stack | `dev.erglytics.com` |
+| User testing / UAT | `uat.erglytics.com` |
+| Authentication (Cognito)| `auth.erglytics.com` |
+
+---
+
+## Certificate Setup (ACM)
+
+All subdomains are covered with the wildcard (*.erglytics) certificate.
+
+This certificate is created in **AWS Certificate Manager (ACM)** and validated through DNS records in GoDaddy (reach out to me if you need the login information).
+
+This allows reuse across multiple stacks without creating a new certificate each time. 
+
+---
+
+## Custom Domain Setup
+
+For each environment:
+
+### 1. Create Custom Domain
+
+Go to:
+
+```text
+API Gateway → Custom domain names
+```
+
+Create:
+
+```text
+dev.erglytics.com
+```
+
+or other environment-specific domain.
+
+Use:
+
+- **Regional**
+- **API mappings only**
+- wildcard certificate (`*.erglytics.com`)
+- TLS 1.2 or newer
+
+---
+
+### 2. DNS Setup (GoDaddy)
+
+Each custom domain needs a CNAME record.
+
+Go to **GoDaddy** *Domain* Settings and navigate to *DNS Records*.
+
+Add a new record, and do it in the following fashion:
+
+for `dev.erglytics.com` you would do
+
+```text
+Type: CNAME
+Name: dev
+Value: (API Gateway domain name)
+```
+
+The `API Gateway domain name` is found on *Endpoint configuration* in the subdomain's details.
+
+Now you must wait on the *Custom Domain Names* page until the *Domain Status* is **Available**.
+
+---
+
+### 3. Add API Mapping
+
+Each domain can have **exactly one root mapping** based on our current implementation.
+
+On the *Custom Domain* details page for the subdomain you're configuring, navigate to the bottom of the page and select **Configure API mappings**.
+
+Add a new mapping in the following style: 
+
+```text
+Domain: dev.erglytics.com
+API: erglytics-dev
+Stage: Prod
+Path: (leave blank)
+```
+
+IMPORTANT:
+Only one blank-path mapping is allowed per domain.
+
+---
+
+### 4. Cognito Configuration
+
+Update the app client callback + sign-out URLs.
+
+Example:
+
+```text
+https://dev.erglytics.com/auth/callback
+https://dev.erglytics.com/signin
+```
+
+---
+
+### 5. Deployment
+
+During deployment, update `AppBaseUrl` to match the stack domain.
+
+Example:
+
+```text
+AppBaseUrl=https://dev.erglytics.com
+```
+
+Also, it is the default, but ensure that `CognitoHostedUiDomain`is set to `auth.erglytics.com` during deployment too. This makes sure that the stack is using the custom domain for the Cognito login/signup pages.
+
+---
+
+## Important Notes:
+
+- With this change you **CANNOT** use raw API Gateway URLs anymore.
+- each stack gets its own subdomain
+- wildcard certificate is reused
+- only one root API mapping per domain
+- Cognito URLs must match the domain
+- wildcard certificate is in east-2, BUT auth certificate has to be in east-1 because of Cognito setup
+
+---
+
+## Common Issues
+
+When setting this up I came across a couple common issues.
+
+### Too many redirects
+
+Usually caused by:
+
+- wrong API mapping
+- duplicate `/Prod`
+- incorrect callback URLs
+
+### Forbidden
+
+Usually means:
+
+- route requires authentication
+- wrong mapping path
+
+### Styles not loading
+
+Usually caused by:
+
+```text
+/Prod/static/...
+```
+
+instead of
+
+```text
+/static/...
+```
+
+Check `ProxyFix` and domain mapping.
+
+Should be fixed by this point, but if this problem reoccurs, then this was how I solved it.

--- a/rowlytics_app/__init__.py
+++ b/rowlytics_app/__init__.py
@@ -18,7 +18,7 @@ def create_app() -> Flask:
     # Initialize logging first
     setup_logging(app)
 
-    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1, x_prefix=1)
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_host=1)
     app.config.from_mapping(
         SECRET_KEY=os.getenv("ROWLYTICS_SECRET_KEY", "dev-secret-key"),
         ROWLYTICS_ENV=os.getenv("ROWLYTICS_ENV", "development"),
@@ -66,7 +66,7 @@ def create_app() -> Flask:
         )
         if not app.config.get("AUTH_REQUIRED"):
             return None
-        if request.path.startswith("/static/"):
+        if request.endpoint == "static" or "/static/" in request.path:
             return None
         if request.endpoint in {
             "public.signin",

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -78,3 +78,14 @@ def test_cognito_login_url_integration() -> None:
     assert query["client_id"] == ["client123"]
     assert query["response_type"] == ["code"]
     assert query["redirect_uri"] == ["https://app.example.com/callback"]
+
+
+def test_signin_route_renders(client: FlaskClient) -> None:
+    response = client.get("/signin")
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert "Login" in html
+
+def test_static_css_loads(client: FlaskClient) -> None:
+    response = client.get("/static/css/styles.css")
+    assert response.status_code == 200


### PR DESCRIPTION
## IMPORTANT

DON'T MERGE UNTIL AFTER ALL CHANGES ARE MADE FOR STACK 0-6-2

## Summary

This PR adds support for using API Gateway custom domains. 

This is separate from the earlier Cognito custom domain work and focuses only on the main application URL.

Closes Issue #127 

## Changes

- switched stack/app configuration to use the custom domain as the public base url
- updated outputs to show the public app URL instead of only the raw API Gateway URL
- updated outputs to show the public app URL instead of only the raw API Gateway URL

## Testing

- created and mapped a custom domain to a test stack: `https://test.erglytics.com`
- added auto testing for issues I came across when creating this (signin route rendering correctly and static css loading)