### PR TITLE
adding stats to team view page

### DIFF
--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -35,6 +35,7 @@ from rowlytics_app.services.dynamodb import (
     list_recordings_page,
     list_team_members_by_team,
     list_team_memberships,
+    list_workouts,
     list_workouts_page,
     normalize_display_name,
     now_iso,
@@ -963,6 +964,108 @@ def _decode_cursor(cursor: str | None) -> dict | None:
     return payload
 
 
+def _numeric_or_none(value):
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        normalized = value.strip().rstrip("%")
+        if not normalized or normalized.lower() in {"n/a", "none", "null"}:
+            return None
+        try:
+            return float(normalized)
+        except ValueError:
+            return None
+    return None
+
+
+def _parse_alignment_details(details: str | None) -> dict[str, str]:
+    if not details:
+        return {}
+
+    parsed = {}
+    for line in details.splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        normalized_key = key.strip().lower()
+        if normalized_key:
+            parsed[normalized_key] = value.strip()
+    return parsed
+
+
+def _workout_metric_value(workout: dict, field_name: str, *detail_keys: str):
+    value = _numeric_or_none(workout.get(field_name))
+    if value is not None:
+        return value
+
+    details = _parse_alignment_details(workout.get("alignmentDetails"))
+    for detail_key in detail_keys:
+        value = _numeric_or_none(details.get(detail_key))
+        if value is not None:
+            return value
+    return None
+
+
+def _summarize_team_workouts(workouts_table, memberships: list[dict]) -> dict:
+    user_ids = sorted({item.get("userId") for item in memberships if item.get("userId")})
+    metrics = {
+        "consistencyScore": {
+            "field": "workoutScore",
+            "detail_keys": ("consistency score", "score"),
+            "sum": 0.0,
+            "count": 0,
+        },
+        "armsStraightScore": {
+            "field": "armsStraightScore",
+            "detail_keys": ("arms straight score",),
+            "sum": 0.0,
+            "count": 0,
+        },
+        "backStraightScore": {
+            "field": "backStraightScore",
+            "detail_keys": ("back straight score",),
+            "sum": 0.0,
+            "count": 0,
+        },
+    }
+    workout_count = 0
+
+    for user_id in user_ids:
+        for workout in list_workouts(workouts_table, user_id):
+            workout_count += 1
+            for metric in metrics.values():
+                value = _workout_metric_value(
+                    workout,
+                    metric["field"],
+                    *metric["detail_keys"],
+                )
+                if value is None:
+                    continue
+                metric["sum"] += value
+                metric["count"] += 1
+
+    return {
+        "memberCount": len(user_ids),
+        "workoutCount": workout_count,
+        "metrics": {
+            name: {
+                "average": (
+                    round(metric["sum"] / metric["count"], 2)
+                    if metric["count"]
+                    else None
+                ),
+                "count": metric["count"],
+            }
+            for name, metric in metrics.items()
+        },
+        "unavailableReason": None,
+    }
+
+
 @api_bp.route("/health", methods=["GET"])
 def health_check():
     """Simple health check endpoint - no auth required to test API connectivity."""
@@ -1088,6 +1191,7 @@ def current_team():
         cursor = _decode_cursor(request.args.get("cursor"))
     except ValueError as err:
         return jsonify({"error": str(err)}), 400
+    include_stats = request.args.get("includeStats", "true").lower() != "false"
 
     try:
         users_table, team_members_table = get_ddb_tables()
@@ -1134,13 +1238,42 @@ def current_team():
         logger.error(f"GET /team/current: failed to load team members: {err}", exc_info=True)
         return jsonify({"error": "Unable to load team members", "detail": str(err)}), 500
 
-    return jsonify({
+    payload = {
         "teamId": team_id,
         "teamName": (team or {}).get("teamName"),
         "members": members,
         "memberRole": membership.get("memberRole"),
         "nextCursor": _encode_cursor(next_key),
-    })
+    }
+
+    if not include_stats:
+        return jsonify(payload)
+
+    team_stats = {
+        "memberCount": len(members),
+        "workoutCount": 0,
+        "metrics": {
+            "consistencyScore": {"average": None, "count": 0},
+            "armsStraightScore": {"average": None, "count": 0},
+            "backStraightScore": {"average": None, "count": 0},
+        },
+        "unavailableReason": None,
+    }
+    try:
+        workouts_table = get_workouts_table()
+        memberships = list_team_members_by_team(team_members_table, team_id)
+        team_stats = _summarize_team_workouts(workouts_table, memberships)
+    except Exception as err:
+        logger.warning(
+            "GET /team/current: unable to load team workout stats for %s: %s",
+            team_id,
+            err,
+            exc_info=True,
+        )
+        team_stats["unavailableReason"] = "Unable to load team workout stats"
+
+    payload["teamStats"] = team_stats
+    return jsonify(payload)
 
 
 @api_bp.route("/team/join", methods=["POST"])

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -894,6 +894,13 @@ body {
   gap: 1rem;
 }
 
+.team-panel__identity {
+  display: grid;
+  justify-items: start;
+  gap: 0.5rem;
+  text-align: left;
+}
+
 .team-panel__hint {
   color: #94a3b8;
   font-size: 0.9rem;
@@ -966,6 +973,43 @@ body {
   font-size: 0.85rem;
 }
 
+.team-stats-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+  text-align: left;
+}
+
+.team-stat-card {
+  min-height: 116px;
+  padding: 0.85rem;
+  border-radius: var(--radius-sm);
+  background: var(--color-detail-surface-strong);
+  border: var(--border-dark);
+  display: grid;
+  align-content: space-between;
+  gap: 0.35rem;
+}
+
+.team-stat-card__value {
+  font-size: 1.45rem;
+  line-height: 1.1;
+  font-weight: 800;
+  color: var(--color-detail-text);
+}
+
+.team-stat-card__label {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--color-detail-text);
+}
+
+.team-stat-card__detail {
+  color: var(--color-muted-dark);
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
 .team-load-more {
   justify-self: center;
 }
@@ -1024,6 +1068,20 @@ body {
 .team-panel--centered .team-members__item {
   background: var(--color-white);
   border: var(--border-light);
+}
+
+.team-panel--centered .team-stat-card {
+  background: var(--color-white);
+  border: var(--border-light);
+}
+
+.team-panel--centered .team-stat-card__value,
+.team-panel--centered .team-stat-card__label {
+  color: var(--color-slate-900);
+}
+
+.team-panel--centered .team-stat-card__detail {
+  color: var(--color-muted-light);
 }
 
 .team-panel--centered .team-members__meta,

--- a/rowlytics_app/static/js/team_view.js
+++ b/rowlytics_app/static/js/team_view.js
@@ -11,6 +11,8 @@
   const createInput = document.getElementById("teamCreateName");
   const teamStatus = document.getElementById("teamStatus");
   const teamIdDisplay = document.getElementById("teamIdDisplay");
+  const teamStatsGrid = document.getElementById("teamStatsGrid");
+  const teamStatsMessage = document.getElementById("teamStatsMessage");
   const teamMembersList = document.getElementById("teamMembersList");
   const teamMembersLoadMore = document.getElementById("teamMembersLoadMore");
   const teamAddForm = document.getElementById("teamAddForm");
@@ -25,6 +27,7 @@
 
   let currentTeamId = null;
   let currentTeamName = null;
+  let currentTeamStats = null;
   let nextMembersCursor = null;
   let members = [];
   let loadingMembers = false;
@@ -42,6 +45,74 @@
     teamMembersLoadMore.classList.toggle("team-load-more--hidden", !nextMembersCursor);
     teamMembersLoadMore.disabled = loading;
     teamMembersLoadMore.textContent = loading ? "Loading..." : "Load more members";
+  };
+
+  const formatPercent = (value) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? `${Math.round(numeric)}%` : "Not available";
+  };
+
+  const buildStatCard = (label, value, detail) => {
+    const card = document.createElement("article");
+    card.className = "team-stat-card";
+
+    const valueEl = document.createElement("p");
+    valueEl.className = "team-stat-card__value";
+    valueEl.textContent = value;
+
+    const labelEl = document.createElement("p");
+    labelEl.className = "team-stat-card__label";
+    labelEl.textContent = label;
+
+    const detailEl = document.createElement("p");
+    detailEl.className = "team-stat-card__detail";
+    detailEl.textContent = detail;
+
+    card.append(valueEl, labelEl, detailEl);
+    return card;
+  };
+
+  const renderTeamStats = (stats) => {
+    if (!teamStatsGrid) return;
+
+    teamStatsGrid.innerHTML = "";
+    if (teamStatsMessage) {
+      teamStatsMessage.textContent = "";
+    }
+
+    if (!stats) {
+      teamStatsGrid.appendChild(buildStatCard("Workouts", "0", "No team workout data yet"));
+      return;
+    }
+
+    const metricCards = [
+      ["Average consistency", stats.metrics?.consistencyScore],
+      ["Average arms straight", stats.metrics?.armsStraightScore],
+      ["Average back straight", stats.metrics?.backStraightScore],
+    ];
+
+    teamStatsGrid.appendChild(
+      buildStatCard(
+        "Members",
+        String(stats.memberCount ?? members.length),
+        `${stats.workoutCount ?? 0} team workouts`,
+      ),
+    );
+
+    metricCards.forEach(([label, metric]) => {
+      const count = metric?.count || 0;
+      teamStatsGrid.appendChild(
+        buildStatCard(
+          label,
+          formatPercent(metric?.average),
+          count ? `${count} workouts included` : "No available scores",
+        ),
+      );
+    });
+
+    if (teamStatsMessage && stats.unavailableReason) {
+      teamStatsMessage.textContent = stats.unavailableReason;
+    }
   };
 
   const renderMembers = () => {
@@ -79,20 +150,26 @@
     teamStatus.textContent = "You're not on a team yet.";
     currentTeamId = null;
     currentTeamName = null;
+    currentTeamStats = null;
     members = [];
     renderMembers();
+    renderTeamStats(null);
     setLoadMoreState(null);
   };
 
-  const showActive = (teamId, teamName, incomingMembers, nextCursor, append) => {
+  const showActive = (teamId, teamName, incomingMembers, nextCursor, append, teamStats) => {
     joinSection.classList.add("team-panel__section--hidden");
     activeSection.classList.remove("team-panel__section--hidden");
     teamStatus.textContent = "You're on a team.";
     teamIdDisplay.textContent = teamName ? `Team name: ${teamName}` : `Team ID: ${teamId}`;
     currentTeamId = teamId;
     currentTeamName = teamName || null;
+    if (teamStats !== undefined) {
+      currentTeamStats = teamStats;
+    }
     members = append ? members.concat(incomingMembers) : incomingMembers;
     renderMembers();
+    renderTeamStats(currentTeamStats);
     setLoadMoreState(nextCursor);
   };
 
@@ -104,6 +181,7 @@
     const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
     if (append && nextMembersCursor) {
       params.set("cursor", nextMembersCursor);
+      params.set("includeStats", "false");
     }
 
     loadingMembers = true;
@@ -124,7 +202,14 @@
         return;
       }
 
-      showActive(data.teamId, data.teamName, data.members || [], data.nextCursor, append);
+      showActive(
+        data.teamId,
+        data.teamName,
+        data.members || [],
+        data.nextCursor,
+        append,
+        data.teamStats,
+      );
     } catch (err) {
       if (!append) {
         showJoin();

--- a/rowlytics_app/templates/team_view.html
+++ b/rowlytics_app/templates/team_view.html
@@ -52,12 +52,19 @@
 
         <section id="teamActiveSection" class="team-panel__section team-panel__section--hidden">
           <div class="team-panel__row">
-            <div>
+            <div class="team-panel__identity">
               <h3>Current team</h3>
               <p id="teamIdDisplay" class="team-panel__hint"></p>
+              <a class="btn btn--subtle" href="{{ url_for('public.template_detail', slug='team-stats') }}">
+                Advanced stats
+              </a>
             </div>
             <button id="teamLeaveBtn" class="btn btn--danger" type="button">Leave team</button>
           </div>
+
+          <h3>Team averages</h3>
+          <div id="teamStatsGrid" class="team-stats-summary"></div>
+          <p id="teamStatsMessage" class="team-panel__hint"></p>
 
           <h3>Members</h3>
           <ul id="teamMembersList" class="team-members"></ul>

--- a/tests/test_workout_api.py
+++ b/tests/test_workout_api.py
@@ -9,7 +9,11 @@ from flask import Flask
 from flask.testing import FlaskClient
 
 from rowlytics_app import create_app
-from rowlytics_app.api_routes import _score_arms_straightness, _score_back_straightness
+from rowlytics_app.api_routes import (
+    _score_arms_straightness,
+    _score_back_straightness,
+    _summarize_team_workouts,
+)
 
 
 @pytest.fixture()
@@ -102,6 +106,46 @@ def test_save_workout_persists_back_straight_score(
     assert response.status_code == 201
     item = workouts_table.put_item.call_args.kwargs["Item"]
     assert item["backStraightScore"] == Decimal("88.5")
+
+
+def test_summarize_team_workouts_averages_available_scores(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workouts_by_user = {
+        "u1": [
+            {
+                "workoutScore": Decimal("80"),
+                "armsStraightScore": Decimal("90"),
+            },
+            {
+                "alignmentDetails": (
+                    "consistency score: 70\n"
+                    "arms straight score: n/a\n"
+                    "back straight score: 60"
+                ),
+            },
+        ],
+        "u2": [
+            {"backStraightScore": 100},
+            {"summary": "No scores for this workout"},
+        ],
+    }
+
+    def fake_list_workouts(_table, user_id: str):
+        return workouts_by_user.get(user_id, [])
+
+    monkeypatch.setattr("rowlytics_app.api_routes.list_workouts", fake_list_workouts)
+
+    stats = _summarize_team_workouts(
+        MagicMock(),
+        [{"userId": "u2"}, {"userId": "u1"}, {"userId": "u1"}],
+    )
+
+    assert stats["memberCount"] == 2
+    assert stats["workoutCount"] == 4
+    assert stats["metrics"]["consistencyScore"] == {"average": 75.0, "count": 2}
+    assert stats["metrics"]["armsStraightScore"] == {"average": 90.0, "count": 1}
+    assert stats["metrics"]["backStraightScore"] == {"average": 80.0, "count": 2}
 
 
 def test_score_arms_straightness_ignores_finish_phase_frames() -> None:


### PR DESCRIPTION
This PR adds overview statistics to the team view page as seen in this screenshot:
<img width="927" height="1032" alt="image" src="https://github.com/user-attachments/assets/ab72bf0d-3308-4fff-ac46-95307797be93" />

The stats give averages of our current stats, show how many workouts have been recorded, and includes how often recorded workouts had valid stats. 

This PR also adds an "Advanced Stats" Button that links to the team stats page (which we will fill out in a future PR).

This PR resolves issue #96.

This PR was deployed to erglytics-dev if you want to test.

Let me know if you guys want changes to this.