### PR TITLE
Adding team stats page and another link to settings page

### DIFF
--- a/rowlytics_app/api_routes.py
+++ b/rowlytics_app/api_routes.py
@@ -4,7 +4,7 @@ import base64
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from uuid import uuid4
 
@@ -35,6 +35,7 @@ from rowlytics_app.services.dynamodb import (
     list_recordings_page,
     list_team_members_by_team,
     list_team_memberships,
+    list_workouts,
     list_workouts_page,
     normalize_display_name,
     now_iso,
@@ -178,11 +179,110 @@ def _parse_iso_datetime(value):
     return parsed.astimezone(timezone.utc)
 
 
+def _now_utc():
+    return datetime.now(timezone.utc)
+
+
 def _normalize_event_timestamp(value):
     parsed = _parse_iso_datetime(value)
     if parsed is None:
-        parsed = datetime.now(timezone.utc)
+        parsed = _now_utc()
     return parsed.isoformat(), parsed
+
+
+def _coerce_score_value(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_workout_completed_at(item):
+    return _parse_iso_datetime(item.get("completedAt") or item.get("createdAt"))
+
+
+def _get_workout_composite_score(item):
+    metric_keys = ("workoutScore", "armsStraightScore", "backStraightScore")
+    values = [
+        value
+        for value in (_coerce_score_value(item.get(metric_key)) for metric_key in metric_keys)
+        if value is not None
+    ]
+    return round(sum(values) / len(values), 2) if values else None
+
+
+def _build_weekly_summary(
+    title,
+    workouts,
+    points,
+    *,
+    team_id=None,
+    team_name=None,
+    member_count=None,
+    empty_state=None,
+):
+    def _average_metric(metric_key):
+        values = [
+            value
+            for value in (_coerce_score_value(workout.get(metric_key)) for workout in workouts)
+            if value is not None
+        ]
+        return round(sum(values) / len(values), 1) if values else None
+
+    return {
+        "title": title,
+        "teamId": team_id,
+        "teamName": team_name,
+        "memberCount": member_count,
+        "workoutCount": len(workouts),
+        "averageScore": _average_metric("workoutScore"),
+        "averageConsistencyScore": _average_metric("workoutScore"),
+        "averageArmsScore": _average_metric("armsStraightScore"),
+        "averageBackScore": _average_metric("backStraightScore"),
+        "points": points,
+        "emptyState": empty_state,
+    }
+
+
+def _collect_weekly_workouts(
+    workouts,
+    *,
+    window_start,
+    window_end,
+    display_name,
+    user_id=None,
+    current_user_id=None,
+    include_current_user_flag=False,
+):
+    weekly_workouts = []
+    points = []
+
+    for workout in workouts:
+        completed_at = _get_workout_completed_at(workout)
+        if completed_at is None or completed_at < window_start or completed_at > window_end:
+            continue
+
+        weekly_workouts.append(workout)
+        score = _get_workout_composite_score(workout)
+        if score is None:
+            continue
+
+        point = {
+            "workoutId": workout.get("workoutId"),
+            "completedAt": completed_at.isoformat(),
+            "score": round(score, 2),
+            "consistencyScore": _coerce_score_value(workout.get("workoutScore")),
+            "armsScore": _coerce_score_value(workout.get("armsStraightScore")),
+            "backScore": _coerce_score_value(workout.get("backStraightScore")),
+            "displayName": display_name,
+            "userId": user_id,
+        }
+        if include_current_user_flag:
+            point["isCurrentUser"] = user_id == current_user_id
+        points.append(point)
+
+    points.sort(key=lambda item: item["completedAt"])
+    return weekly_workouts, points
 
 
 def _resolve_recording_user_id(data):
@@ -1140,6 +1240,123 @@ def current_team():
         "members": members,
         "memberRole": membership.get("memberRole"),
         "nextCursor": _encode_cursor(next_key),
+    })
+
+
+@api_bp.route("/team/stats/weekly", methods=["GET"])
+def weekly_team_stats():
+    user_id = session.get("user_id")
+    if not user_id:
+        return jsonify({"error": "authentication required"}), 401
+
+    window_end = _now_utc()
+    window_start = window_end - timedelta(days=7)
+
+    try:
+        users_table, team_members_table = get_ddb_tables()
+        teams_table = get_teams_table()
+        workouts_table = get_workouts_table()
+    except RuntimeError as err:
+        return jsonify({"error": str(err)}), 500
+
+    try:
+        profile = fetch_user_profile(user_id)
+    except Exception as err:
+        return jsonify({"error": "Unable to load account profile", "detail": str(err)}), 500
+
+    display_name = (
+        profile.get("name")
+        or session.get("user_name")
+        or session.get("user_email")
+        or user_id
+        or "Current user"
+    )
+
+    try:
+        membership = get_team_membership(team_members_table, user_id)
+    except Exception as err:
+        return jsonify({"error": "Unable to load team membership", "detail": str(err)}), 500
+
+    try:
+        user_workouts = list_workouts(workouts_table, user_id)
+    except Exception as err:
+        return jsonify({"error": "Unable to load workouts", "detail": str(err)}), 500
+
+    weekly_user_workouts, user_points = _collect_weekly_workouts(
+        user_workouts,
+        window_start=window_start,
+        window_end=window_end,
+        display_name=display_name,
+        user_id=user_id,
+        current_user_id=user_id,
+    )
+    user_summary = _build_weekly_summary(display_name, weekly_user_workouts, user_points)
+
+    team_summary = _build_weekly_summary(
+        "No team yet",
+        [],
+        [],
+        empty_state="Join or create a team to see team-wide weekly scores.",
+    )
+
+    if membership:
+        team_id = membership.get("teamId")
+        try:
+            team = get_team(teams_table, team_id)
+            members = fetch_team_members(
+                users_table,
+                team_members_table,
+                team_id,
+                ALLOWED_TEAM_ROLES,
+            )
+        except Exception as err:
+            return jsonify({"error": "Unable to load team details", "detail": str(err)}), 500
+
+        team_name = (team or {}).get("teamName") or "Current team"
+        team_points = []
+        team_workouts = []
+        for member in members:
+            member_user_id = member.get("userId")
+            if not member_user_id:
+                continue
+
+            member_display_name = member.get("name") or member_user_id
+            try:
+                member_workouts = list_workouts(workouts_table, member_user_id)
+            except Exception as err:
+                return jsonify({
+                    "error": "Unable to load team workouts",
+                    "detail": str(err),
+                }), 500
+
+            weekly_member_workouts, member_points = _collect_weekly_workouts(
+                member_workouts,
+                window_start=window_start,
+                window_end=window_end,
+                display_name=member_display_name,
+                user_id=member_user_id,
+                current_user_id=user_id,
+                include_current_user_flag=True,
+            )
+            team_workouts.extend(weekly_member_workouts)
+            team_points.extend(member_points)
+
+        team_points.sort(key=lambda item: item["completedAt"])
+        team_summary = _build_weekly_summary(
+            team_name,
+            team_workouts,
+            team_points,
+            team_id=team_id,
+            team_name=team_name,
+            member_count=len(members),
+            empty_state="No team workouts with scores were recorded in this window.",
+        )
+
+    return jsonify({
+        "windowStart": window_start.isoformat(),
+        "windowEnd": window_end.isoformat(),
+        "user": user_summary,
+        "team": team_summary,
     })
 
 

--- a/rowlytics_app/routes.py
+++ b/rowlytics_app/routes.py
@@ -87,24 +87,24 @@ TEMPLATE_CARDS: tuple[TemplateCard, ...] = (
         template_name="team_view.html",
     ),
     TemplateCard(
-        slug="manage-team",
-        title="Manage Team",
-        blurb="Currently a placeholder.",
-        image_path=(
-            "https://rowlytics-static-assets.s3.us-east-2.amazonaws.com/"
-            "images/team_settings_cool.png"
-            ),
-        template_name="manage_team.html",
-    ),
-    TemplateCard(
         slug="team-stats",
         title="Team Stats",
-        blurb="Currently a placeholder.",
+        blurb="Compare your weekly scores with your team's progress.",
         image_path=(
             "https://rowlytics-static-assets.s3.us-east-2.amazonaws.com/"
             "images/stats_cool.png"
             ),
         template_name="team_stats.html",
+    ),
+    TemplateCard(
+        slug="manage-team",
+        title="Account Settings",
+        blurb="Update your name and manage your account.",
+        image_path=(
+            "https://rowlytics-static-assets.s3.us-east-2.amazonaws.com/"
+            "images/team_settings_cool.png"
+            ),
+        template_name="manage_team.html",
     ),
 )
 
@@ -153,6 +153,8 @@ def landing_page() -> str:
 
 @public_bp.route("/templates/<slug>")
 def template_detail(slug: str) -> str:
+    if slug == "manage-team":
+        return redirect(url_for("public.settings"))
     card = _get_card(slug)
     if card is None:
         abort(404)

--- a/rowlytics_app/static/css/styles.css
+++ b/rowlytics_app/static/css/styles.css
@@ -1032,6 +1032,258 @@ body {
   font-weight: 600;
 }
 
+/* Team stats */
+.team-stats {
+  margin: 1.5rem auto 0;
+}
+
+.team-stats__header {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.team-stats__range {
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.team-stats__message {
+  min-height: 1.2rem;
+  font-size: 0.92rem;
+  color: var(--color-text);
+  font-weight: 600;
+}
+
+.team-stats__message--error {
+  color: #991b1b;
+}
+
+.team-stats__message--success {
+  color: #166534;
+}
+
+.team-stats__summaries {
+  display: grid;
+  gap: 1rem;
+}
+
+.team-stats-card {
+  background:
+    linear-gradient(140deg, rgba(255, 255, 255, 0.98), rgba(232, 243, 255, 0.92)),
+    var(--color-white);
+  border: var(--border-light);
+  border-radius: 20px;
+  box-shadow: var(--shadow-card-light);
+  padding: 1rem 1.1rem;
+  display: grid;
+  gap: 0.7rem;
+}
+
+.team-stats-card--team {
+  background:
+    linear-gradient(140deg, rgba(245, 252, 244, 0.98), rgba(220, 245, 230, 0.94)),
+    var(--color-white);
+}
+
+.team-stats-card__eyebrow {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: #4a6485;
+  font-weight: 800;
+}
+
+.team-stats-card__title {
+  margin: 0;
+  color: var(--color-slate-900);
+  font-size: 1.18rem;
+}
+
+.team-stats-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.65rem;
+}
+
+.team-stats-card__metric {
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: 0.2rem;
+}
+
+.team-stats-card__label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #4a6485;
+  font-weight: 700;
+}
+
+.team-stats-card__value {
+  font-size: clamp(1.05rem, 2.3vw, 1.45rem);
+  line-height: 1;
+  color: #111111;
+  font-weight: 800;
+}
+
+.team-stats-card__meta {
+  margin: 0;
+  color: #284b73;
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.team-stats__charts {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.team-chart-card {
+  background: rgba(255, 255, 255, 0.98);
+  border: var(--border-light);
+  border-radius: 20px;
+  box-shadow: var(--shadow-card-light);
+  padding: 1rem;
+  display: grid;
+  gap: 0.55rem;
+}
+
+.team-chart-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.45rem;
+  align-items: start;
+}
+
+.team-chart-card__header h2 {
+  margin: 0;
+  color: var(--color-slate-900);
+  font-size: 1.08rem;
+  line-height: 1.05;
+}
+
+.team-chart-card__hint {
+  margin: 0.18rem 0 0;
+  color: #4a6485;
+  font-weight: 600;
+  font-size: 0.83rem;
+  line-height: 1.2;
+}
+
+.team-chart-card__plot {
+  min-height: 0;
+  display: grid;
+  align-items: start;
+}
+
+.team-chart-card__empty {
+  min-height: 340px;
+  display: grid;
+  place-items: center;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.5);
+  background: rgba(241, 245, 249, 0.65);
+  color: #4a6485;
+  font-weight: 700;
+  text-align: center;
+  padding: 1rem;
+}
+
+.team-chart {
+  width: 100%;
+  height: auto;
+  display: block;
+  overflow: visible;
+}
+
+.team-chart__title {
+  fill: #0f172a;
+  font-size: 15px;
+  font-weight: 800;
+}
+
+.team-chart__axis {
+  stroke: #475569;
+  stroke-width: 1.5;
+}
+
+.team-chart__grid {
+  stroke: rgba(148, 163, 184, 0.28);
+  stroke-width: 1;
+}
+
+.team-chart__tick {
+  stroke: #64748b;
+  stroke-width: 1;
+}
+
+.team-chart__axis-label {
+  fill: #475569;
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.team-chart__axis-title {
+  fill: #0f172a;
+  font-size: 13px;
+  font-weight: 800;
+}
+
+.team-chart__point {
+  fill: #0f766e;
+  stroke: rgba(15, 118, 110, 0.22);
+  stroke-width: 6;
+}
+
+.team-chart__point--team {
+  fill: #2563eb;
+  stroke: rgba(37, 99, 235, 0.22);
+}
+
+.team-chart__point--current {
+  fill: #f97316;
+  stroke: rgba(249, 115, 22, 0.22);
+}
+
+@media (max-width: 720px) {
+  .team-stats-card {
+    padding: 0.9rem;
+  }
+
+  .team-stats-card__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .team-stats-card__value {
+    font-size: 1.1rem;
+  }
+
+  .team-chart-card__plot,
+  .team-chart-card__empty {
+    min-height: 0;
+  }
+
+  .team-chart-card__empty {
+    min-height: 300px;
+  }
+
+  .team-chart__title {
+    font-size: 17px;
+  }
+
+  .team-chart__axis-label {
+    font-size: 15px;
+  }
+
+  .team-chart__axis-title {
+    font-size: 15px;
+  }
+}
+
 /* Recordings */
 .recordings-panel {
   background: var(--color-detail-surface);

--- a/rowlytics_app/static/js/team_stats.js
+++ b/rowlytics_app/static/js/team_stats.js
@@ -1,0 +1,275 @@
+(() => {
+  const rangeText = document.getElementById("teamStatsRange");
+  const message = document.getElementById("teamStatsMessage");
+  const userStatsTitle = document.getElementById("userStatsTitle");
+  const userWorkoutCount = document.getElementById("userWorkoutCount");
+  const userConsistencyScore = document.getElementById("userConsistencyScore");
+  const userArmsScore = document.getElementById("userArmsScore");
+  const userBackScore = document.getElementById("userBackScore");
+  const teamStatsTitle = document.getElementById("teamStatsTitle");
+  const teamWorkoutCount = document.getElementById("teamWorkoutCount");
+  const teamConsistencyScore = document.getElementById("teamConsistencyScore");
+  const teamArmsScore = document.getElementById("teamArmsScore");
+  const teamBackScore = document.getElementById("teamBackScore");
+  const teamMemberCount = document.getElementById("teamMemberCount");
+  const userChartHint = document.getElementById("userChartHint");
+  const teamChartHint = document.getElementById("teamChartHint");
+  const userScatterChart = document.getElementById("userScatterChart");
+  const teamScatterChart = document.getElementById("teamScatterChart");
+
+  if (
+    !rangeText ||
+    !message ||
+    !userStatsTitle ||
+    !userConsistencyScore ||
+    !userArmsScore ||
+    !userBackScore ||
+    !teamStatsTitle ||
+    !teamConsistencyScore ||
+    !teamArmsScore ||
+    !teamBackScore ||
+    !userScatterChart ||
+    !teamScatterChart
+  ) {
+    return;
+  }
+
+  const getApiUrl = (path) => path;
+
+  const setMessage = (text, tone) => {
+    message.textContent = text;
+    message.classList.remove("team-stats__message--error", "team-stats__message--success");
+    if (tone === "error") {
+      message.classList.add("team-stats__message--error");
+    }
+    if (tone === "success") {
+      message.classList.add("team-stats__message--success");
+    }
+  };
+
+  const formatDateRange = (windowStart, windowEnd) => {
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    return `${formatter.format(windowStart)} to ${formatter.format(windowEnd)}`;
+  };
+
+  const formatScore = (value) => (typeof value === "number" ? `${value.toFixed(1)}%` : "--");
+
+  const formatCount = (value) => {
+    const count = Number(value);
+    return Number.isFinite(count) ? String(count) : "0";
+  };
+
+  const renderSummary = (summary, elements, fallbackMeta) => {
+    elements.title.textContent = summary.title || "Untitled";
+    elements.workoutCount.textContent = formatCount(summary.workoutCount);
+    elements.consistencyScore.textContent = formatScore(summary.averageConsistencyScore);
+    elements.armsScore.textContent = formatScore(summary.averageArmsScore);
+    elements.backScore.textContent = formatScore(summary.averageBackScore);
+
+    if (!elements.meta) {
+      return;
+    }
+
+    if (typeof summary.memberCount === "number" && summary.memberCount > 0) {
+      elements.meta.textContent = `${summary.memberCount} team member${summary.memberCount === 1 ? "" : "s"}`;
+      return;
+    }
+
+    elements.meta.textContent = fallbackMeta || "";
+  };
+
+  const escapeHtml = (value) =>
+    String(value)
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#39;");
+
+  const describeMetric = (label, value) => `${label}: ${typeof value === "number" ? `${value.toFixed(1)}%` : "n/a"}`;
+
+  const renderScatter = (container, points, options) => {
+    const {
+      emptyText,
+      windowStart,
+      windowEnd,
+      accentClass,
+      chartTitle,
+    } = options;
+
+    if (!Array.isArray(points) || !points.length) {
+      container.innerHTML = `<div class="team-chart-card__empty">${escapeHtml(emptyText)}</div>`;
+      return;
+    }
+
+    const isMobile = window.matchMedia("(max-width: 720px)").matches;
+    const width = isMobile ? 680 : 760;
+    const height = isMobile ? 455 : 410;
+    const margin = isMobile
+      ? { top: 8, right: 18, bottom: 114, left: 76 }
+      : { top: 8, right: 22, bottom: 102, left: 84 };
+    const plotWidth = width - margin.left - margin.right;
+    const plotHeight = height - margin.top - margin.bottom;
+    const startMs = windowStart.getTime();
+    const endMs = windowEnd.getTime();
+    const spanMs = Math.max(endMs - startMs, 1);
+    const yTicks = [0, 25, 50, 75, 100];
+    const tickCount = isMobile ? 4 : 7;
+    const axisFontSize = isMobile ? 24 : 20;
+    const axisTitleFontSize = isMobile ? 26 : 22;
+
+    const xFormatter = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+    });
+    const tooltipFormatter = new Intl.DateTimeFormat(undefined, {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+    const xFor = (timestampMs) =>
+      margin.left + ((timestampMs - startMs) / spanMs) * plotWidth;
+    const yFor = (score) =>
+      margin.top + plotHeight - (Math.max(0, Math.min(100, score)) / 100) * plotHeight;
+
+    const xTicks = [];
+    const tickStep = spanMs / Math.max(tickCount - 1, 1);
+    for (let index = 0; index < tickCount; index += 1) {
+      const tickMs = Math.min(startMs + index * tickStep, endMs);
+      xTicks.push({
+        label: xFormatter.format(new Date(tickMs)),
+        x: xFor(tickMs),
+      });
+    }
+
+    const gridLines = yTicks
+      .map((tick) => {
+        const y = yFor(tick);
+        return `
+          <line class="team-chart__grid" x1="${margin.left}" y1="${y}" x2="${width - margin.right}" y2="${y}"></line>
+          <text class="team-chart__axis-label" style="font-size:${axisFontSize}px" x="${margin.left - 14}" y="${y + 7}" text-anchor="end">${tick}</text>
+        `;
+      })
+      .join("");
+
+    const tickLines = xTicks
+      .map(
+        (tick) => `
+          <line class="team-chart__tick" x1="${tick.x}" y1="${height - margin.bottom}" x2="${tick.x}" y2="${height - margin.bottom + 6}"></line>
+          <text class="team-chart__axis-label" style="font-size:${axisFontSize}px" x="${tick.x}" y="${height - 54}" text-anchor="middle">${escapeHtml(tick.label)}</text>
+        `,
+      )
+      .join("");
+
+    const circles = points
+      .map((point) => {
+        const timestamp = new Date(point.completedAt);
+        const circleClass = point.isCurrentUser ? "team-chart__point team-chart__point--current" : accentClass;
+        const x = xFor(timestamp.getTime());
+        const y = yFor(Number(point.score));
+        const title = [
+          `${point.displayName || "Workout"}: ${Number(point.score).toFixed(1)}% composite`,
+          `Completed: ${tooltipFormatter.format(timestamp)}`,
+          describeMetric("Consistency", point.consistencyScore),
+          describeMetric("Arms", point.armsScore),
+          describeMetric("Back", point.backScore),
+        ].join(" | ");
+        return `
+          <circle class="${circleClass}" cx="${x}" cy="${y}" r="5">
+            <title>${escapeHtml(title)}</title>
+          </circle>
+        `;
+      })
+      .join("");
+
+    container.innerHTML = `
+      <svg class="team-chart" viewBox="0 0 ${width} ${height}" role="img" aria-label="${escapeHtml(chartTitle)}">
+        <line class="team-chart__axis" x1="${margin.left}" y1="${margin.top}" x2="${margin.left}" y2="${height - margin.bottom}" />
+        <line class="team-chart__axis" x1="${margin.left}" y1="${height - margin.bottom}" x2="${width - margin.right}" y2="${height - margin.bottom}" />
+        ${gridLines}
+        ${tickLines}
+        ${circles}
+        <text class="team-chart__axis-title" style="font-size:${axisTitleFontSize}px" x="${width / 2}" y="${height - 10}" text-anchor="middle">Workout completion date</text>
+        <text class="team-chart__axis-title" style="font-size:${axisTitleFontSize}px" x="22" y="${height / 2}" text-anchor="middle" transform="rotate(-90 22 ${height / 2})">Composite score (%)</text>
+      </svg>
+    `;
+  };
+
+  const loadTeamStats = async () => {
+    setMessage("Loading team statistics...");
+
+    try {
+      const response = await fetch(getApiUrl("/api/team/stats/weekly"));
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload.error || "Unable to load team statistics");
+      }
+
+      const windowStart = new Date(payload.windowStart);
+      const windowEnd = new Date(payload.windowEnd);
+      const userSummary = payload.user || {};
+      const teamSummary = payload.team || {};
+
+      rangeText.textContent = `Weekly window: ${formatDateRange(windowStart, windowEnd)}`;
+      userChartHint.textContent = `${formatCount(userSummary.workoutCount)} workouts in this window. A combined score is the average of a workout's consistency, arms, and back scores.`;
+      teamChartHint.textContent = teamSummary.teamId
+        ? `${formatCount(teamSummary.workoutCount)} team workouts in this window. A combined score is the average of a workout's consistency, arms, and back scores.`
+        : (teamSummary.emptyState || "Join a team to see team-wide scores.");
+
+      renderSummary(
+        userSummary,
+        {
+          title: userStatsTitle,
+          workoutCount: userWorkoutCount,
+          consistencyScore: userConsistencyScore,
+          armsScore: userArmsScore,
+          backScore: userBackScore,
+        },
+      );
+
+      renderSummary(
+        teamSummary,
+        {
+          title: teamStatsTitle,
+          workoutCount: teamWorkoutCount,
+          consistencyScore: teamConsistencyScore,
+          armsScore: teamArmsScore,
+          backScore: teamBackScore,
+          meta: teamMemberCount,
+        },
+        teamSummary.emptyState,
+      );
+
+      renderScatter(userScatterChart, userSummary.points || [], {
+        windowStart,
+        windowEnd,
+        emptyText: "No workouts with score data for this user in the last 7 days.",
+        accentClass: "team-chart__point",
+        chartTitle: "Your weekly composite workout scores",
+      });
+
+      renderScatter(teamScatterChart, teamSummary.points || [], {
+        windowStart,
+        windowEnd,
+        emptyText: teamSummary.emptyState || "No team workouts with score data in the last 7 days.",
+        accentClass: "team-chart__point team-chart__point--team",
+        chartTitle: "Team weekly composite workout scores",
+      });
+
+      setMessage("");
+    } catch (err) {
+      setMessage(err.message || "Unable to load team statistics", "error");
+      userStatsTitle.textContent = "Unavailable";
+      teamStatsTitle.textContent = "Unavailable";
+      userScatterChart.innerHTML = '<div class="team-chart-card__empty">Unable to load chart data.</div>';
+      teamScatterChart.innerHTML = '<div class="team-chart-card__empty">Unable to load chart data.</div>';
+    }
+  };
+
+  loadTeamStats();
+})();

--- a/rowlytics_app/templates/team_stats.html
+++ b/rowlytics_app/templates/team_stats.html
@@ -2,16 +2,94 @@
 
 {% block title %}Team Stats{% endblock %}
 
+{% block header %}
+  {% include "partials/masthead.html" %}
+{% endblock %}
+
 {% block content %}
-{% include "partials/masthead.html" %}
+<main class="page page-pad">
+  <section class="team-stats container stack">
+    <div class="team-stats__header">
+      <h1>Team Statistics</h1>
+      <p id="teamStatsRange" class="team-stats__range">Loading the last 7 days of workout scores...</p>
+    </div>
 
-<main class="page page-pad container stack">
-  <h1>Team Statistics</h1>
+    <p id="teamStatsMessage" class="team-stats__message" aria-live="polite"></p>
 
-  <p>
-    Team statistics will appear here once team functionality is implemented.
-  </p>
+    <section class="team-stats__summaries" aria-label="Weekly summaries">
+      <article class="team-stats-card">
+        <div class="team-stats-card__eyebrow">Your Week</div>
+        <h2 id="userStatsTitle" class="team-stats-card__title">Loading...</h2>
+        <div class="team-stats-card__metrics">
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Workouts</span>
+            <span id="userWorkoutCount" class="team-stats-card__value">--</span>
+          </div>
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Consistency</span>
+            <span id="userConsistencyScore" class="team-stats-card__value">--</span>
+          </div>
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Arms</span>
+            <span id="userArmsScore" class="team-stats-card__value">--</span>
+          </div>
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Back</span>
+            <span id="userBackScore" class="team-stats-card__value">--</span>
+          </div>
+        </div>
+      </article>
 
-  <p>This page is currently a placeholder.</p>
+      <article class="team-stats-card team-stats-card--team">
+        <div class="team-stats-card__eyebrow">Team Week</div>
+        <h2 id="teamStatsTitle" class="team-stats-card__title">Loading...</h2>
+        <div class="team-stats-card__metrics">
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Workouts</span>
+            <span id="teamWorkoutCount" class="team-stats-card__value">--</span>
+          </div>
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Consistency</span>
+            <span id="teamConsistencyScore" class="team-stats-card__value">--</span>
+          </div>
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Arms</span>
+            <span id="teamArmsScore" class="team-stats-card__value">--</span>
+          </div>
+          <div class="team-stats-card__metric">
+            <span class="team-stats-card__label">Back</span>
+            <span id="teamBackScore" class="team-stats-card__value">--</span>
+          </div>
+        </div>
+        <p id="teamMemberCount" class="team-stats-card__meta"></p>
+      </article>
+    </section>
+
+    <section class="team-stats__charts" aria-label="Weekly scatter plots">
+      <article class="team-chart-card">
+        <div class="team-chart-card__header">
+          <div>
+            <h2>Your Composite Scores</h2>
+            <p id="userChartHint" class="team-chart-card__hint">Each point is one workout's combined score, which is the average of its consistency, arms, and back scores.</p>
+          </div>
+        </div>
+        <div id="userScatterChart" class="team-chart-card__plot" aria-live="polite"></div>
+      </article>
+
+      <article class="team-chart-card">
+        <div class="team-chart-card__header">
+          <div>
+            <h2>Team Composite Scores</h2>
+            <p id="teamChartHint" class="team-chart-card__hint">Each point is one team workout's combined score, which is the average of its consistency, arms, and back scores.</p>
+          </div>
+        </div>
+        <div id="teamScatterChart" class="team-chart-card__plot" aria-live="polite"></div>
+      </article>
+    </section>
+  </section>
 </main>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/team_stats.js') }}" defer></script>
 {% endblock %}

--- a/tests/test_team_stats_api.py
+++ b/tests/test_team_stats_api.py
@@ -1,0 +1,226 @@
+"""Tests for weekly team stats aggregation."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+from flask import Flask
+from flask.testing import FlaskClient
+
+from rowlytics_app import create_app
+
+
+@pytest.fixture()
+def app() -> Flask:
+    flask_app = create_app()
+    flask_app.config.update(TESTING=True, AUTH_REQUIRED=False)
+    return flask_app
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    return app.test_client()
+
+
+def test_weekly_team_stats_requires_auth(client: FlaskClient) -> None:
+    response = client.get("/api/team/stats/weekly")
+
+    assert response.status_code == 401
+    assert response.get_json() == {"error": "authentication required"}
+
+
+def test_weekly_team_stats_returns_user_and_team_aggregates(
+    client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = datetime(2026, 4, 23, 15, 0, tzinfo=timezone.utc)
+    workouts_by_user = {
+        "user-1": [
+            {
+                "workoutId": "u1-a",
+                "completedAt": "2026-04-22T14:00:00+00:00",
+                "workoutScore": Decimal("80"),
+                "armsStraightScore": Decimal("70"),
+                "backStraightScore": Decimal("88"),
+            },
+            {
+                "workoutId": "u1-b",
+                "completedAt": "2026-04-20T16:00:00+00:00",
+                "workoutScore": Decimal("90"),
+                "armsStraightScore": Decimal("92"),
+                "backStraightScore": Decimal("84"),
+            },
+            {
+                "workoutId": "u1-c",
+                "completedAt": "2026-04-21T16:00:00+00:00",
+                "armsStraightScore": Decimal("81"),
+            },
+            {
+                "workoutId": "u1-old",
+                "completedAt": "2026-04-10T16:00:00+00:00",
+                "workoutScore": Decimal("60"),
+            },
+        ],
+        "user-2": [
+            {
+                "workoutId": "u2-a",
+                "completedAt": "2026-04-21T09:00:00+00:00",
+                "workoutScore": Decimal("70"),
+                "armsStraightScore": Decimal("76"),
+                "backStraightScore": Decimal("73"),
+            },
+            {
+                "workoutId": "u2-b",
+                "completedAt": "2026-04-19T11:00:00+00:00",
+                "workoutScore": Decimal("100"),
+                "armsStraightScore": Decimal("98"),
+                "backStraightScore": Decimal("91"),
+            },
+        ],
+    }
+
+    monkeypatch.setattr("rowlytics_app.api_routes._now_utc", lambda: fixed_now)
+    monkeypatch.setattr("rowlytics_app.api_routes.get_ddb_tables", lambda: (object(), object()))
+    monkeypatch.setattr("rowlytics_app.api_routes.get_teams_table", lambda: object())
+    monkeypatch.setattr("rowlytics_app.api_routes.get_workouts_table", lambda: object())
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.fetch_user_profile",
+        lambda user_id: {"userId": user_id, "name": "Noah"},
+    )
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.get_team_membership",
+        lambda team_members_table, user_id: {"teamId": "team-1", "memberRole": "rower"},
+    )
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.get_team",
+        lambda teams_table, team_id: {"teamId": team_id, "teamName": "Erglytics Varsity"},
+    )
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.fetch_team_members",
+        lambda users_table, team_members_table, team_id, allowed_roles: [
+            {"userId": "user-1", "name": "Noah"},
+            {"userId": "user-2", "name": "Ava"},
+        ],
+    )
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.list_workouts",
+        lambda workouts_table, user_id: workouts_by_user[user_id],
+    )
+
+    with client.session_transaction() as session:
+        session["user_id"] = "user-1"
+        session["user_name"] = "Noah"
+
+    response = client.get("/api/team/stats/weekly")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["windowStart"] == "2026-04-16T15:00:00+00:00"
+    assert payload["windowEnd"] == "2026-04-23T15:00:00+00:00"
+
+    assert payload["user"]["title"] == "Noah"
+    assert payload["user"]["workoutCount"] == 3
+    assert payload["user"]["averageScore"] == 85.0
+    assert payload["user"]["averageConsistencyScore"] == 85.0
+    assert payload["user"]["averageArmsScore"] == 81.0
+    assert payload["user"]["averageBackScore"] == 86.0
+    assert [point["workoutId"] for point in payload["user"]["points"]] == ["u1-b", "u1-c", "u1-a"]
+    assert [point["score"] for point in payload["user"]["points"]] == [88.67, 81.0, 79.33]
+
+    assert payload["team"]["title"] == "Erglytics Varsity"
+    assert payload["team"]["teamId"] == "team-1"
+    assert payload["team"]["memberCount"] == 2
+    assert payload["team"]["workoutCount"] == 5
+    assert payload["team"]["averageScore"] == 85.0
+    assert payload["team"]["averageConsistencyScore"] == 85.0
+    assert payload["team"]["averageArmsScore"] == 83.4
+    assert payload["team"]["averageBackScore"] == 84.0
+    assert [point["workoutId"] for point in payload["team"]["points"]] == [
+        "u2-b",
+        "u1-b",
+        "u2-a",
+        "u1-c",
+        "u1-a",
+    ]
+    assert [point["score"] for point in payload["team"]["points"]] == [
+        96.33,
+        88.67,
+        73.0,
+        81.0,
+        79.33,
+    ]
+    assert [point["isCurrentUser"] for point in payload["team"]["points"]] == [
+        False,
+        True,
+        False,
+        True,
+        True,
+    ]
+
+
+def test_weekly_team_stats_returns_empty_team_state_when_user_has_no_team(
+    client: FlaskClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fixed_now = datetime(2026, 4, 23, 15, 0, tzinfo=timezone.utc)
+
+    monkeypatch.setattr("rowlytics_app.api_routes._now_utc", lambda: fixed_now)
+    monkeypatch.setattr("rowlytics_app.api_routes.get_ddb_tables", lambda: (object(), object()))
+    monkeypatch.setattr("rowlytics_app.api_routes.get_teams_table", lambda: object())
+    monkeypatch.setattr("rowlytics_app.api_routes.get_workouts_table", lambda: object())
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.fetch_user_profile",
+        lambda user_id: {"userId": user_id, "name": "Rower One"},
+    )
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.get_team_membership",
+        lambda team_members_table, user_id: None,
+    )
+    monkeypatch.setattr(
+        "rowlytics_app.api_routes.list_workouts",
+        lambda workouts_table, user_id: [
+            {
+                "workoutId": "solo-1",
+                "completedAt": "2026-04-22T14:00:00+00:00",
+                "workoutScore": Decimal("77.5"),
+                "armsStraightScore": Decimal("81"),
+                "backStraightScore": Decimal("88"),
+            },
+        ],
+    )
+
+    with client.session_transaction() as session:
+        session["user_id"] = "user-1"
+        session["user_name"] = "Rower One"
+
+    response = client.get("/api/team/stats/weekly")
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["user"]["title"] == "Rower One"
+    assert payload["user"]["workoutCount"] == 1
+    assert payload["user"]["averageScore"] == 77.5
+    assert payload["user"]["averageConsistencyScore"] == 77.5
+    assert payload["user"]["averageArmsScore"] == 81.0
+    assert payload["user"]["averageBackScore"] == 88.0
+    assert payload["user"]["points"] == [
+        {
+            "armsScore": 81.0,
+            "backScore": 88.0,
+            "completedAt": "2026-04-22T14:00:00+00:00",
+            "consistencyScore": 77.5,
+            "displayName": "Rower One",
+            "score": 82.17,
+            "userId": "user-1",
+            "workoutId": "solo-1",
+        }
+    ]
+    assert payload["team"]["title"] == "No team yet"
+    assert payload["team"]["teamId"] is None
+    assert payload["team"]["workoutCount"] == 0
+    assert payload["team"]["averageScore"] is None
+    assert payload["team"]["averageConsistencyScore"] is None
+    assert payload["team"]["averageArmsScore"] is None
+    assert payload["team"]["averageBackScore"] is None
+    assert payload["team"]["points"] == []


### PR DESCRIPTION
## Big Evil Scary PR 3

This PR should hopefully be the last abhorrently large PR of the project.

This PR replaces the "Team Stats" placeholder with a real weekly stats dashboard and makes the remaining tile be "Account Settings" (it's just another link to account settings lol).

### Team Stats Page:

Here is what the new page looks like before getting into it:
<img width="932" height="940" alt="image" src="https://github.com/user-attachments/assets/6f521daa-c5fb-4318-9c25-80381abbc251" />


Here is a more in-depth description of the Team Stats page (it is the majority of this PR):
- I replaced the placeholder `Team Stats` page with a real dashboard.
- I added stacked weekly summary cards for:
  - the current user
  - the current team
- I added two scatter plots:
  - user weekly composite scores
  - team weekly composite scores
- I added clear axis titles axis labels for readability across devices.

To make these changes I added a weekly stats API:
- I added a new authenticated endpoint: `GET /api/team/stats/weekly` that returns:
  - rolling 7-day window bounds
  - user weekly summary
  - team weekly summary
  - scatter plot points for both views
- Summary metrics now include:
  - workout count
  - average consistency score
  - average arms score
  - average back score
- Scatter plot points use a combined/composite score:
  - average of the available consistency, arms, and back scores for a workout
- Team points also mark whether a point belongs to the current user.

### Home tile update
- I added descriptions to tiles that previously just had placeholders.
- I renamed the `Manage Team` tile to `Account Settings`.
- I swapped the order of `Team Stats` and `Account Settings` on the home screen.

Here is what the home page looks like now:
<img width="938" height="866" alt="image" src="https://github.com/user-attachments/assets/69d5b8cf-279a-4956-99c4-db2f977ee2f6" />

### Additional Details
- The weekly stats window is a rolling 7-day window ending at request time.
- Workout grouping uses `completedAt`, with fallback to `createdAt` when needed.
- Workouts missing one of the three score components can still appear on the graph if at least one score is available.
- Combined score definition shown on the page:
  - average of a workout’s consistency, arms, and back scores

This PR should close issue #160.

This PR was deployed to erglytics-UAT for testing.